### PR TITLE
fix: project management GH action

### DIFF
--- a/.github/workflows/project_management.yml
+++ b/.github/workflows/project_management.yml
@@ -3,10 +3,10 @@
 name: 'Project Board Automation'
 
 "on":
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [synchronize, opened, reopened, labeled, unlabeled, ready_for_review, review_requested, converted_to_draft, closed]
-  pull_request_target:
+  pull_request:
     branches: [main]
     types: [synchronize, opened, reopened, labeled, unlabeled, ready_for_review, review_requested, converted_to_draft, closed]
   pull_request_review:
@@ -29,6 +29,10 @@ env:
   DONE_COLUMN_NAME: '"Done"'
   ITERATION_FIELD_NAME: 'Sprint'   # See project settings (default is `Iteration`)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   project-board-automation:
     name: 'Linked Issues & Project Board Automation'
@@ -44,7 +48,7 @@ jobs:
       - name: 'Get linked issue id and state'
         id: linked-issue
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
         run: |
           gh api graphql -f query='
             query($pr_url: URI!) {


### PR DESCRIPTION
Close vegaprotocol/devops-infra#1555   

- use PAT rather than token so works cross public and private repos

- Add concurrency to avoid multiple jobs running