### PR TITLE
chore: rename DeHistory to NetworkHistory in HCVault

### DIFF
--- a/cmd/secrets/fillOut.go
+++ b/cmd/secrets/fillOut.go
@@ -143,6 +143,12 @@ func fillOutNodeData(nodeSecrets *secrets.VegaNodePrivate) (updatedFields map[st
 		updatedFields["DeHistoryPeerId"] = nodeSecrets.DeHistoryPeerId
 		updatedFields["DeHistoryPrivateKey"] = nodeSecrets.DeHistoryPrivateKey
 	}
+	if len(nodeSecrets.NetworkHistoryPeerId) == 0 || len(nodeSecrets.NetworkHistoryPrivateKey) == 0 {
+		nodeSecrets.NetworkHistoryPeerId = nodeSecrets.DeHistoryPeerId
+		nodeSecrets.NetworkHistoryPrivateKey = nodeSecrets.DeHistoryPrivateKey
+		updatedFields["NetworkHistoryPeerId"] = nodeSecrets.NetworkHistoryPeerId
+		updatedFields["NetworkHistoryPrivateKey"] = nodeSecrets.NetworkHistoryPrivateKey
+	}
 
 	return
 }

--- a/secrets/node.go
+++ b/secrets/node.go
@@ -22,8 +22,10 @@ type VegaNodePrivate struct {
 	VegaRecoveryPhrase string  `json:"vega_recovery_phrase"`
 	VegaPubKeyIndex    *uint64 `json:"vega_public_key_index"`
 	// Data-Node DeHistory
-	DeHistoryPeerId     string `json:"de_history_peer_id"`
-	DeHistoryPrivateKey string `json:"de_history_private_key"`
+	DeHistoryPeerId          string `json:"de_history_peer_id"`
+	DeHistoryPrivateKey      string `json:"de_history_private_key"`
+	NetworkHistoryPeerId     string `json:"network_history_peer_id"`
+	NetworkHistoryPrivateKey string `json:"network_history_private_key"`
 	// Tendermint
 	TendermintNodeId              string `json:"tendermint_node_id"`
 	TendermintNodePubKey          string `json:"tendermint_node_public_key"`


### PR DESCRIPTION
add functionality to duplicate values from de_history_ fields to network_history_ fields in HCVault

Then you can run it as:
```bash
go run main.go secrets fill-out --network [network name]
```
for every network
Optionally, you can add `--node n10` to limit the changes to a single node (good to test on a single node before applying to all of them).

closes vegaprotocol/devopstools#29