### PR TITLE
feat: avoid panic when secret is missing

### DIFF
--- a/secrets/hcvault/secret.go
+++ b/secrets/hcvault/secret.go
@@ -28,13 +28,16 @@ func (c *HCVaultSecretStore) GetSecret(root string, path string) (map[string]int
 func (c *HCVaultSecretStore) GetSecretWithPath(path string) (map[string]interface{}, error) {
 	resp, err := c.Client.Logical().Read(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get '%s' secret from Vega Vault %w", path, err)
+		return nil, fmt.Errorf("failed to get '%s' secret from Vega Vault: %w", path, err)
 	}
-	if resp == nil {
+	if resp == nil || resp.Data == nil || resp.Data["data"] == nil {
 		return nil, fmt.Errorf("secret '%s' from Vega Vault is empty", path)
 	}
 
-	data := resp.Data["data"].(map[string]interface{})
+	data, conversionOk := resp.Data["data"].(map[string]interface{})
+	if !conversionOk {
+		return nil, fmt.Errorf("failed to convert secret %s", path)
+	}
 
 	if data == nil {
 		return nil, fmt.Errorf("value for secret '%s' is empty", path)


### PR DESCRIPTION
When secret is empty it returns the following panic:

```
Exception has occurred: panic
"interface conversion: interface {} is nil, not string"
Stack:
	 3  0x0000000001261068 in github.com/vegaprotocol/devopstools/secrets/hcvault.(*HCVaultSecretStore).GetInfuraProjectId
	     at /home/daniel/www/devopstools/secrets/hcvault/services.go:12
	 4  0x00000000011419f2 in github.com/vegaprotocol/devopstools/ethutils.(*EthereumClientManager).GetEthereumURL
	     at /home/daniel/www/devopstools/ethutils/clientmanager.go:37
	 5  0x000000000114285d in github.com/vegaprotocol/devopstools/ethutils.(*EthereumClientManager).GetEthClient
	     at /home/daniel/www/devopstools/ethutils/clientmanager.go:65
	 6  0x0000000001581cd3 in github.com/vegaprotocol/devopstools/veganetwork.NewVegaNetwork
	     at /home/daniel/www/devopstools/veganetwork/network.go:83
	 7  0x000000000158461a in github.com/vegaprotocol/devopstools/cmd.(*RootArgs).ConnectToVegaNetwork
	     at /home/daniel/www/devopstools/cmd/veganetwork.go:33
	 8  0x00000000015a5925 in github.com/vegaprotocol/devopstools/cmd/topup.RunTopUpTraderbot
	     at /home/daniel/www/devopstools/cmd/topup/traderbot.go:59
	 9  0x00000000015a52ee in github.com/vegaprotocol/devopstools/cmd/topup.glob..func3
	     at /home/daniel/www/devopstools/cmd/topup/traderbot.go:32
	10  0x0000000001343814 in github.com/spf13/cobra.(*Command).execute
	     at /home/daniel/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:920
	11  0x00000000013447d1 in github.com/spf13/cobra.(*Command).ExecuteC
	     at /home/daniel/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044
	12  0x0000000001343d8f in github.com/spf13/cobra.(*Command).Execute
	     at /home/daniel/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
	13  0x0000000001583e72 in github.com/vegaprotocol/devopstools/cmd.Execute
	     at /home/daniel/www/devopstools/cmd/root.go:38
	14  0x0000000001867277 in main.main
	     at /home/daniel/www/devopstools/main.go:21
```