### PR TITLE
feat: improve snapshot-compatibility load-snapshot command to avoid vanished file error

### DIFF
--- a/cmd/snapshotcompatibility/produce-new-snapshot.go
+++ b/cmd/snapshotcompatibility/produce-new-snapshot.go
@@ -123,7 +123,7 @@ func moveNullChainNetworkForward(
 		5*time.Second,
 		logger,
 	)
-	dialContext, dialCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	dialContext, dialCancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer dialCancel()
 	coreClient.MustDialConnectionIgnoreTime(dialContext)
 
@@ -160,7 +160,7 @@ func moveNullChainNetworkForward(
 	}
 
 	go func(logger *zap.Logger, stopChannel <-chan struct{}, port string) {
-		ticker := time.NewTicker(1000 * time.Millisecond)
+		ticker := time.NewTicker(5000 * time.Millisecond)
 		forwardBody := []byte(`{"forward": "30s"}`)
 		for {
 			select {

--- a/cmd/snapshotcompatibility/produce-new-snapshot.go
+++ b/cmd/snapshotcompatibility/produce-new-snapshot.go
@@ -119,7 +119,7 @@ func moveNullChainNetworkForward(
 	logger.Info("Crateing Core GRPC client")
 	coreClient := core.NewCoreClient(
 		[]string{fmt.Sprintf("localhost:%s", coreGRPCPort)},
-		5*time.Second,
+		15*time.Second,
 		logger,
 	)
 	dialContext, dialCancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -131,7 +131,7 @@ func moveNullChainNetworkForward(
 	if err != nil {
 		return fmt.Errorf("failed to get network parameters from core api: %w", err)
 	}
-	if len(networkParameters) < 0 {
+	if len(networkParameters) <= 0 {
 		return fmt.Errorf(
 			"failed to get network parameters from core api: empty list returned",
 		)
@@ -159,7 +159,7 @@ func moveNullChainNetworkForward(
 	}
 
 	go func(logger *zap.Logger, stopChannel <-chan struct{}, port string) {
-		ticker := time.NewTicker(500 * time.Millisecond)
+		ticker := time.NewTicker(1000 * time.Millisecond)
 		forwardBody := []byte(`{"forward": "30s"}`)
 		for {
 			select {

--- a/tools/retry.go
+++ b/tools/retry.go
@@ -1,0 +1,35 @@
+package tools
+
+import (
+	"fmt"
+	"time"
+)
+
+func RetryReturn[K any](retryAmount int, retryDelay time.Duration, handler func() (K, error)) (K, error) {
+	if retryAmount < 1 {
+		retryAmount = 1
+	}
+	if retryDelay < 1 {
+		retryDelay = 200 * time.Millisecond
+	}
+
+	var (
+		allErrors []string
+		lastError error
+	)
+
+	for i := 0; i < retryAmount; i++ {
+		res, err := handler()
+		if err != nil {
+			lastError = err
+			allErrors = append(allErrors, err.Error())
+			time.Sleep(retryDelay)
+			continue
+		}
+
+		return res, nil
+	}
+
+	var result K
+	return result, fmt.Errorf("failed to run handler for %d times, last error: %w, all errors: %v", retryAmount, lastError, allErrors)
+}

--- a/tools/retry.go
+++ b/tools/retry.go
@@ -33,3 +33,30 @@ func RetryReturn[K any](retryAmount int, retryDelay time.Duration, handler func(
 	var result K
 	return result, fmt.Errorf("failed to run handler for %d times, last error: %w, all errors: %v", retryAmount, lastError, allErrors)
 }
+
+func RetryRun(retryAmount int, retryDelay time.Duration, handler func() error) error {
+	if retryAmount < 1 {
+		retryAmount = 1
+	}
+	if retryDelay < 1 {
+		retryDelay = 200 * time.Millisecond
+	}
+
+	var (
+		allErrors []string
+		lastError error
+	)
+
+	for i := 0; i < retryAmount; i++ {
+		if err := handler(); err != nil {
+			lastError = err
+			allErrors = append(allErrors, err.Error())
+			time.Sleep(retryDelay)
+			continue
+		}
+
+		return nil
+	}
+
+	return fmt.Errorf("failed to run handler for %d times, last error: %w, all errors: %v", retryAmount, lastError, allErrors)
+}


### PR DESCRIPTION
# Changes

- Added retry logic
- Removed additional thread for the null chain forward move
- Changed logic of how we download snapshots from the mainnet - now we copy it to a temporary location before we download it.


# Related PRs:

- https://github.com/vegaprotocol/vega/pull/8887
- https://github.com/vegaprotocol/jenkins-shared-library/pull/568
- https://github.com/vegaprotocol/devopstools/pull/53
- https://github.com/vegaprotocol/system-tests/pull/2323


# Triggered builds:

- https://jenkins.ops.vega.xyz/job/common/job/system-tests-snapshot-compatibility/46/
- https://jenkins.ops.vega.xyz/job/common/job/system-tests-snapshot-compatibility/45
- https://jenkins.ops.vega.xyz/job/common/job/system-tests-snapshot-compatibility/43