### PR TITLE
fix: healthy nodes subcommand for the mainnet

### DIFF
--- a/cmd/network/healthynodes.go
+++ b/cmd/network/healthynodes.go
@@ -41,8 +41,9 @@ func init() {
 }
 
 type output struct {
-	Validators []string `json: "validators"`
+	Validators []string `json:"validators"`
 	DataNodes  []string `json:"data_nodes"`
+	All        []string `json:"all"`
 }
 
 func RunHealthyNodes(args HealthyNodesArgs) error {
@@ -102,6 +103,7 @@ func RunHealthyNodes(args HealthyNodesArgs) error {
 	result := output{
 		Validators: healthyValidators,
 		DataNodes:  healthyDataNodes,
+		All:        append(healthyValidators, healthyDataNodes...),
 	}
 
 	resp, err := json.MarshalIndent(result, "", "    ")

--- a/networktools/network.go
+++ b/networktools/network.go
@@ -30,7 +30,7 @@ func NewNetworkTools(
 	case types.NetworkFairground:
 		network.DNSSuffix = "testnet.vega.xyz"
 	case types.NetworkMainnet:
-		network.DNSSuffix = ""
+		network.DNSSuffix = "vega.community"
 	case types.NetworkDevnet1:
 		network.DNSSuffix = fmt.Sprintf("%s.vega.rocks", name)
 	default:

--- a/networktools/nodes.go
+++ b/networktools/nodes.go
@@ -86,6 +86,7 @@ func (network *NetworkTools) GetNetworkDataNodes(healthyOnly bool) []string {
 	hosts := []string{}
 	previousMissing := false
 	for _, host := range network.ListNodes() {
+		host := fmt.Sprintf("api.%s", host)
 		if _, err := tools.GetIP(host); err != nil {
 			if previousMissing && network.Name != types.NetworkMainnet {
 				break // There is no DNS for this and previous nodes, there is no reason to check other nodes


### PR DESCRIPTION


```shell
➜  devopstools git:(fix-healthy-nodes-command-for-mainnet) ✗ go run main.go network healthy-nodes --network fairground --github-token $GITHUB_TOKEN
{
    "validators": [
        "n01.testnet.vega.xyz",
        "n02.testnet.vega.xyz",
        "n03.testnet.vega.xyz",
        "n04.testnet.vega.xyz",
        "n05.testnet.vega.xyz"
    ],
    "data_nodes": [
        "api.n00.testnet.vega.xyz",
        "api.n06.testnet.vega.xyz",
        "api.n07.testnet.vega.xyz",
        "api.n08.testnet.vega.xyz",
        "api.n09.testnet.vega.xyz"
    ],
    "all": [
        "n01.testnet.vega.xyz",
        "n02.testnet.vega.xyz",
        "n03.testnet.vega.xyz",
        "n04.testnet.vega.xyz",
        "n05.testnet.vega.xyz",
        "api.n00.testnet.vega.xyz",
        "api.n06.testnet.vega.xyz",
        "api.n07.testnet.vega.xyz",
        "api.n08.testnet.vega.xyz",
        "api.n09.testnet.vega.xyz"
    ]
}
➜  devopstools git:(fix-healthy-nodes-command-for-mainnet) ✗ go run main.go network healthy-nodes --network mainnet --github-token $GITHUB_TOKEN        
{
    "validators": [
        "be0.vega.community",
        "api0.vega.community",
        "be1.vega.community",
        "api1.vega.community",
        "be2.vega.community",
        "api2.vega.community",
        "api7.vega.community"
    ],
    "data_nodes": [],
    "all": [
        "be0.vega.community",
        "api0.vega.community",
        "be1.vega.community",
        "api1.vega.community",
        "be2.vega.community",
        "api2.vega.community",
        "api7.vega.community"
    ]
}
➜  devopstools git:(fix-healthy-nodes-command-for-mainnet) ✗ 
```