### PR TITLE
Referrral min staked update

### DIFF
--- a/governance/referral/referral.go
+++ b/governance/referral/referral.go
@@ -43,15 +43,15 @@ func NewCreateSimpleReferralSetProposal(closingTime time.Time, enactmentTime tim
 						},
 						StakingTiers: []*vega.StakingTier{
 							{
-								MinimumStakedTokens:      "100",
+								MinimumStakedTokens:      "1",
 								ReferralRewardMultiplier: "1",
 							},
 							{
-								MinimumStakedTokens:      "1000",
+								MinimumStakedTokens:      "2",
 								ReferralRewardMultiplier: "2",
 							},
 							{
-								MinimumStakedTokens:      "10000",
+								MinimumStakedTokens:      "3",
 								ReferralRewardMultiplier: "3",
 							},
 						},


### PR DESCRIPTION
Min staked for referrals set to, 1, 2, 3
In order for it to be easier for users to setup referral codes on incentives using the different tiers.