### PR TITLE
feat: Improve mainnet snapshot compatibility

### DIFF
--- a/cmd/propose/referral.go
+++ b/cmd/propose/referral.go
@@ -114,7 +114,7 @@ func setupNetworkParametersToSetupReferralProgram(
 	updateParams := map[string]string{
 		"governance.proposal.referralProgram.minEnact": "5s",
 		"governance.proposal.referralProgram.minClose": "5s",
-		"referralProgram.maxReferralTiers":             "3",
+		"referralProgram.maxReferralTiers":             "10",
 		"referralProgram.maxReferralDiscountFactor":    "0.02",
 		"referralProgram.maxReferralRewardFactor":      "0.02",
 	}

--- a/cmd/snapshotcompatibility/download-binary.go
+++ b/cmd/snapshotcompatibility/download-binary.go
@@ -1,0 +1,220 @@
+package snapshotcompatibility
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/vegaprotocol/devopstools/tools"
+	"go.uber.org/zap"
+)
+
+type DownloadBinaryArgs struct {
+	*SnapshotCompatibilityArgs
+
+	Destination      string
+	CoreRESTEndpoint string
+	Repository       string
+}
+
+var downloadBinaryArgs DownloadBinaryArgs
+
+var downloadBinaryCmd = &cobra.Command{
+	Use:   "download-binary",
+	Short: "Download the binary which is running on given core endpoint",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runDownloadBinary(downloadBinaryArgs.Logger,
+			downloadBinaryArgs.Destination,
+			downloadBinaryArgs.CoreRESTEndpoint,
+			downloadBinaryArgs.Repository,
+		); err != nil {
+			downloadMainnetSnapshotArgs.Logger.Fatal(
+				"failed to prepare for snapshot compatibility pipeline",
+				zap.Error(err),
+			)
+
+			return
+		}
+	},
+}
+
+func init() {
+	downloadBinaryArgs.SnapshotCompatibilityArgs = &snapshotCompatibilityArgs
+
+	downloadBinaryCmd.PersistentFlags().
+		StringVar(
+			&downloadBinaryArgs.Destination,
+			"destination",
+			"./vega-mainnet",
+			"Path, where the binary is downloaded",
+		)
+	downloadBinaryCmd.PersistentFlags().
+		StringVar(
+			&downloadBinaryArgs.CoreRESTEndpoint,
+			"core-rest-endpoint",
+			"https://api2.vega.community",
+			"URL to the vega core REST API",
+		)
+	downloadBinaryCmd.PersistentFlags().
+		StringVar(
+			&downloadBinaryArgs.Repository,
+			"repository",
+			"vegaprotocol/vega",
+			"Repository, where are the binaries",
+		)
+}
+
+type statisticsResponse struct {
+	Statistics struct {
+		AppVersion string `json:"appVersion"`
+	} `json:"statistics"`
+}
+
+func getStatistics(endpoint string) (*statisticsResponse, error) {
+	if !strings.HasPrefix(endpoint, "http") {
+		endpoint = fmt.Sprintf("https://%s", endpoint)
+	}
+
+	url := strings.Join([]string{strings.TrimRight(endpoint, "/"), "statistics"}, "/")
+
+	return tools.RetryReturn(3, 3*time.Second, func() (*statisticsResponse, error) {
+		resp, err := http.Get(url)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get response from statistic: %w", err)
+		}
+		defer resp.Body.Close()
+
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read response body for statistics: %w", err)
+		}
+
+		result := &statisticsResponse{}
+		if err := json.Unmarshal(body, result); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal statistics response: %w", err)
+		}
+
+		return result, nil
+	})
+}
+
+func downloadURL(binaryVersion, repository, artifactName string) (string, error) {
+	url := fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", repository, binaryVersion, artifactName)
+
+	resp, err := http.Head(url)
+	if err == nil && resp.StatusCode == http.StatusOK {
+		return url, nil
+	}
+
+	return "", fmt.Errorf("failed to get existing url for asset binary %s/%s: %w", binaryVersion, artifactName, err)
+}
+
+func downloadVegaBinary(logger *zap.Logger, repository, version, destinationFile string) error {
+	artifactName := tools.FormatAssetName("vega", "zip")
+
+	logger.Info(
+		"Ensuring binary is available to download",
+		zap.String("version", version),
+		zap.String("artifact", artifactName),
+	)
+	url, err := downloadURL(version, repository, artifactName)
+	if err != nil {
+		return fmt.Errorf("failed to download vega binary: expected version of vega not found: %w", err)
+	}
+
+	logger.Info("Downloading vega binary", zap.String("url", url))
+
+	c := http.Client{
+		Timeout: time.Second * 120,
+	}
+	resp, err := c.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to get vega binary release from %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	// Check server response
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to get vega binary release with bad status: %q", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read request body: %w", err)
+	}
+
+	logger.Info("Extracting vega binary from archive")
+	zReader, err := zip.NewReader(bytes.NewReader(body), resp.ContentLength)
+	if err != nil {
+		return fmt.Errorf("failed to unzip vega package: %w", err)
+	}
+
+	file, err := zReader.Open("vega")
+	if err != nil {
+		return fmt.Errorf("failed to get vega binary from unzipped folder: %w", err)
+	}
+	defer file.Close()
+
+	if err := os.RemoveAll(destinationFile); err != nil {
+		return fmt.Errorf("failed to remove existing destination file: %w", err)
+	}
+
+	binFile, err := os.Create(destinationFile)
+	if err != nil {
+		return fmt.Errorf("failed to create destination file: %w", err)
+	}
+	defer binFile.Close()
+
+	err = os.Chmod(destinationFile, 0755)
+	if err != nil {
+		return fmt.Errorf("failed to change permission for file %q: %w", destinationFile, err)
+	}
+
+	if _, err := io.Copy(binFile, file); err != nil {
+		return fmt.Errorf("failed to copy content to file %q: %w", destinationFile, err)
+	}
+
+	defer func() {
+		if err != nil {
+			_ = os.Remove(binFile.Name())
+		}
+	}()
+
+	logger.Info("Vega binary was successfully extracted")
+
+	return nil
+}
+
+func runDownloadBinary(
+	logger *zap.Logger,
+	destination, coreRESTEndpoint, repository string,
+) error {
+	logger.Info("Getting version from the core rest api", zap.String("endpoint", coreRESTEndpoint))
+
+	stats, err := getStatistics(coreRESTEndpoint)
+	if err != nil {
+		return fmt.Errorf("failed to get statistics for endpoint(%s): %w", coreRESTEndpoint, err)
+	}
+	logger.Info("Vega version got correctly", zap.String("version", stats.Statistics.AppVersion))
+
+	if err := downloadVegaBinary(logger, repository, stats.Statistics.AppVersion, destination); err != nil {
+		return fmt.Errorf("failed to download vega version: %w", err)
+	}
+
+	stdOut, err := tools.ExecuteBinary(destination, []string{"version"}, nil)
+	if err != nil {
+		return fmt.Errorf("downloaded vega binary looks broken: %s, %w", stdOut, err)
+	}
+
+	logger.Info(fmt.Sprintf("Vega version: %s", stdOut))
+
+	return nil
+}

--- a/cmd/snapshotcompatibility/download-mainnet-snapshot.go
+++ b/cmd/snapshotcompatibility/download-mainnet-snapshot.go
@@ -47,7 +47,7 @@ var downloadMainnetSnapshotCmd = &cobra.Command{
 			downloadMainnetSnapshotArgs.TemporaryDestination,
 		); err != nil {
 			downloadMainnetSnapshotArgs.Logger.Fatal(
-				"failed to prepare for snapshot compatibility pipeline",
+				"failed to download mainnet snapshot",
 				zap.Error(err),
 			)
 

--- a/cmd/snapshotcompatibility/download-mainnet-snapshot.go
+++ b/cmd/snapshotcompatibility/download-mainnet-snapshot.go
@@ -32,12 +32,45 @@ type DownloadMainnetSnapshotArgs struct {
 	SnapshotServerKeyFile  string
 }
 
+func (args DownloadMainnetSnapshotArgs) Check() error {
+	if args.SnapshotServerHost == "" {
+		return fmt.Errorf(
+			"no snapshot server provided: provide value with the --snapshot-server flag",
+		)
+	}
+
+	if args.SnapshotRemoteLocation == "" {
+		return fmt.Errorf(
+			"snapshot remote locatino not provided: provide value with the --snapshot-remote-location flag",
+		)
+	}
+
+	if args.SnapshotServerUser == "" {
+		return fmt.Errorf(
+			"snapshot server user not provided: provide value with the --snapshot-server-user flag",
+		)
+	}
+
+	if !tools.FileExists(args.SnapshotServerKeyFile) {
+		return fmt.Errorf(
+			"snapshot server key does not exist: provide value with the --snapshot-server-key flag",
+		)
+	}
+
+	return nil
+}
+
 var downloadMainnetSnapshotArgs DownloadMainnetSnapshotArgs
 
 var downloadMainnetSnapshotCmd = &cobra.Command{
 	Use:   "download-mainnet-snapshot",
 	Short: "Download the snapshot from the mainnet and put it in the local folder",
 	Run: func(cmd *cobra.Command, args []string) {
+		if err := downloadMainnetSnapshotArgs.Check(); err != nil {
+			loadSnapshotArgs.Logger.Fatal("invalid input", zap.Error(err))
+			return
+		}
+
 		if err := runDownloadMainnetSnapshot(downloadMainnetSnapshotArgs.Logger,
 			downloadMainnetSnapshotArgs.SnapshotServerHost,
 			downloadMainnetSnapshotArgs.SnapshotServerUser,

--- a/cmd/snapshotcompatibility/download-mainnet-snapshot.go
+++ b/cmd/snapshotcompatibility/download-mainnet-snapshot.go
@@ -1,0 +1,241 @@
+package snapshotcompatibility
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	sshlib "golang.org/x/crypto/ssh"
+
+	"github.com/vegaprotocol/devopstools/ssh"
+	"github.com/vegaprotocol/devopstools/tools"
+)
+
+var (
+	VegaSnapshotPath   = filepath.Join("state", "node", "snapshots")
+	VegaCoreConfigPath = filepath.Join("config", "node", "config.toml")
+	RemoteVegaPath     = "/home/vega/vegavisor_home/current/vega"
+)
+
+type DownloadMainnetSnapshotArgs struct {
+	*SnapshotCompatibilityArgs
+
+	RemoteVegaBinary     string
+	TemporaryDestination string
+
+	SnapshotServerHost     string
+	SnapshotRemoteLocation string
+	SnapshotServerUser     string
+	SnapshotServerKeyFile  string
+}
+
+var downloadMainnetSnapshotArgs DownloadMainnetSnapshotArgs
+
+var downloadMainnetSnapshotCmd = &cobra.Command{
+	Use:   "download-mainnet-snapshot",
+	Short: "Download the snapshot from the mainnet and put it in the local folder",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runDownloadMainnetSnapshot(downloadMainnetSnapshotArgs.Logger,
+			downloadMainnetSnapshotArgs.SnapshotServerHost,
+			downloadMainnetSnapshotArgs.SnapshotServerUser,
+			downloadMainnetSnapshotArgs.SnapshotServerKeyFile,
+			downloadMainnetSnapshotArgs.SnapshotRemoteLocation,
+			downloadMainnetSnapshotArgs.RemoteVegaBinary,
+			downloadMainnetSnapshotArgs.TemporaryDestination,
+		); err != nil {
+			downloadMainnetSnapshotArgs.Logger.Fatal(
+				"failed to prepare for snapshot compatibility pipeline",
+				zap.Error(err),
+			)
+
+			return
+		}
+	},
+}
+
+func init() {
+	downloadMainnetSnapshotArgs.SnapshotCompatibilityArgs = &snapshotCompatibilityArgs
+
+	currentUser, _ := tools.WhoAmI()
+	downloadMainnetSnapshotCmd.PersistentFlags().
+		StringVar(
+			&downloadMainnetSnapshotArgs.RemoteVegaBinary,
+			"remote-vega-binary",
+			RemoteVegaPath,
+			"Path to the vega executable on remote machine",
+		)
+	downloadMainnetSnapshotCmd.PersistentFlags().
+		StringVar(
+			&downloadMainnetSnapshotArgs.TemporaryDestination,
+			"local-temporary-destination",
+			"/tmp/mainnet-snapshot",
+			"Path on the local machine, where we download the mainnet snapshot",
+		)
+	downloadMainnetSnapshotCmd.PersistentFlags().
+		StringVar(
+			&downloadMainnetSnapshotArgs.SnapshotServerHost,
+			"snapshot-server",
+			"",
+			"The source server for the snapshot",
+		)
+	downloadMainnetSnapshotCmd.PersistentFlags().
+		StringVar(
+			&downloadMainnetSnapshotArgs.SnapshotServerUser,
+			"snapshot-server-user",
+			currentUser,
+			"The SSH user for the snapshot server",
+		)
+	downloadMainnetSnapshotCmd.PersistentFlags().
+		StringVar(
+			&downloadMainnetSnapshotArgs.SnapshotRemoteLocation,
+			"snapshot-remote-location",
+			"/home/vega/vega_home/state/node/snapshots",
+			"The location where the snapshot is on the remote server",
+		)
+	downloadMainnetSnapshotCmd.PersistentFlags().
+		StringVar(
+			&downloadMainnetSnapshotArgs.SnapshotServerKeyFile,
+			"snapshot-server-key-file",
+			filepath.Join(tools.CurrentUserHomePath(), ".ssh", "id_rsa"),
+			"The SSH private key used to authenticate user",
+		)
+}
+
+func runDownloadMainnetSnapshot(
+	logger *zap.Logger,
+	snapshotServerHost, snapshotServerUser, snapshotServerKeyFile, snapshotRemoteLocation string,
+	RemoteVegaBinary, snapshotTempDestination string,
+) error {
+	snapshotRemoteTempLocation := fmt.Sprintf("/tmp/snapshots-db-%d/snapshots", time.Now().UnixMicro())
+
+	logger.Info("Creating SSH client",
+		zap.String("host", snapshotServerHost),
+		zap.String("user", snapshotServerUser),
+		zap.String("keyfile", snapshotServerKeyFile))
+
+	sshClient, err := ssh.GetSSHConnection(snapshotServerHost, snapshotServerUser, snapshotServerKeyFile)
+	if err != nil {
+		return fmt.Errorf("failed to create ssh connection client: %w", err)
+	}
+
+	err = tools.RetryRun(3, 5*time.Second, func() error {
+		logger.Info("Trying to copy snapshot.db on remote server into temporary location")
+		return copySnapshotOnRemote(logger,
+			RemoteVegaBinary,
+			sshClient,
+			snapshotRemoteLocation,
+			snapshotRemoteTempLocation)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to copy snapshot on remote temp location: %w", err)
+	}
+	defer remoteCleanup(logger, sshClient, filepath.Dir(snapshotRemoteTempLocation))
+
+	logger.Info("Cleaning the local temp folder up", zap.String("path", snapshotTempDestination))
+	if err := os.RemoveAll(snapshotTempDestination); err != nil {
+		return fmt.Errorf("failed to cleanup temp destination(%s): %w", snapshotTempDestination, err)
+	}
+
+	logger.Info("Ensuring local temp path exist", zap.String("path", snapshotTempDestination))
+	if err := os.MkdirAll(snapshotRemoteTempLocation, os.ModePerm); err != nil {
+		return fmt.Errorf("failed to create temporary dir to download snapshot db: %w", err)
+	}
+
+	logger.Info(
+		"Downloading the snapshot db",
+		zap.String("server", fmt.Sprintf("%s@%s", snapshotServerUser, snapshotServerHost)),
+		zap.String("source path", snapshotRemoteTempLocation),
+		zap.String("destination", snapshotTempDestination),
+	)
+
+	err = tools.RetryRun(3, 5*time.Second, func() error {
+		logger.Info("Trying to download snapshot-db")
+		return ssh.Download(
+			snapshotServerHost,
+			snapshotServerUser,
+			snapshotServerKeyFile,
+			snapshotRemoteTempLocation,
+			snapshotTempDestination,
+			logger,
+		)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to download snapshot db: %w", err)
+	}
+	logger.Info("Snapshot database downloaded")
+	return nil
+}
+
+func remoteCleanup(logger *zap.Logger, sshClient *sshlib.Client, filePath string) error {
+	cleanupCommand := fmt.Sprintf("rm -fr %s || echo 'OK'", filePath)
+	logger.Info("Cleaning the remote server up",
+		zap.String("filepath", filePath))
+
+	if stdout, err := ssh.RunCommandWithClient(sshClient, cleanupCommand); err != nil {
+		return fmt.Errorf("failed to cleanup on remote: output: %s: %s", stdout, err)
+	}
+
+	return nil
+}
+
+func copySnapshotOnRemote(logger *zap.Logger,
+	RemoteVegaBinary string,
+	sshClient *sshlib.Client,
+	source, destination string,
+) error {
+	cleanupCommand := fmt.Sprintf("rm -fr %s || echo 'OK'", destination)
+	logger.Info("Cleaning the destination up",
+		zap.String("filepath", destination))
+
+	if stdout, err := ssh.RunCommandWithClient(sshClient, cleanupCommand); err != nil {
+		logger.Error(
+			"failed to cleanup on remote",
+			zap.String("stdout", stdout),
+			zap.Error(err),
+		)
+		return fmt.Errorf("failed to cleanup on remote: output: %s: %s", stdout, err)
+	}
+
+	mkdirCommand := fmt.Sprintf("mkdir -p %s", filepath.Dir(destination))
+	logger.Info("Ensuring destination directory exists",
+		zap.String("command", mkdirCommand))
+
+	if stdout, err := ssh.RunCommandWithClient(sshClient, mkdirCommand); err != nil {
+		logger.Error(
+			"failed to ensure destination directory exists",
+			zap.String("stdout", stdout),
+			zap.Error(err),
+		)
+		return fmt.Errorf("failed to ensure destination directory exists: output: %s: %s", stdout, err)
+	}
+
+	copyCommand := fmt.Sprintf("cp -r %s %s", source, destination)
+
+	logger.Info("Copying snapshot db to temp location",
+		zap.String("command", copyCommand))
+	if stdout, err := ssh.RunCommandWithClient(sshClient, copyCommand); err != nil {
+		logger.Error(
+			fmt.Sprintf("failed to copy snapshot from %s to %s on remote: output", source, destination),
+			zap.String("stdout", stdout),
+			zap.Error(err),
+		)
+		return fmt.Errorf("failed to copy snapshot from %s to %s on remote: output: %s: %s", source, destination, stdout, err)
+	}
+
+	checkCommand := fmt.Sprintf("%s tools snapshot --db-path '%s'", RemoteVegaBinary, destination)
+	logger.Info("Checking if copied snapshot was copied correctly",
+		zap.String("command", checkCommand))
+	if stdout, err := ssh.RunCommandWithClient(sshClient, checkCommand); err != nil {
+		logger.Error(
+			"failed to check if snapshot was correctly copied on remote",
+			zap.String("stdout", stdout),
+			zap.Error(err),
+		)
+		return fmt.Errorf("failed to check if snapshot was correctly copied on remote: output: %s: %w", stdout, err)
+	}
+
+	return nil
+}

--- a/cmd/snapshotcompatibility/load-snapshot.go
+++ b/cmd/snapshotcompatibility/load-snapshot.go
@@ -1,390 +1,390 @@
 package snapshotcompatibility
 
-import (
-	"fmt"
-	"os"
-	"path/filepath"
-	"sort"
-	"time"
+// import (
+// 	"fmt"
+// 	"os"
+// 	"path/filepath"
+// 	"sort"
+// 	"time"
 
-	"github.com/spf13/cobra"
-	"github.com/tomwright/dasel"
-	"github.com/tomwright/dasel/storage"
-	"go.uber.org/zap"
-	sshlib "golang.org/x/crypto/ssh"
+// 	"github.com/spf13/cobra"
+// 	"github.com/tomwright/dasel"
+// 	"github.com/tomwright/dasel/storage"
+// 	"go.uber.org/zap"
+// 	sshlib "golang.org/x/crypto/ssh"
 
-	"github.com/vegaprotocol/devopstools/ssh"
-	"github.com/vegaprotocol/devopstools/tools"
-	"github.com/vegaprotocol/devopstools/vegacapsule"
-	"github.com/vegaprotocol/devopstools/vegacmd"
-)
+// 	"github.com/vegaprotocol/devopstools/ssh"
+// 	"github.com/vegaprotocol/devopstools/tools"
+// 	"github.com/vegaprotocol/devopstools/vegacapsule"
+// 	"github.com/vegaprotocol/devopstools/vegacmd"
+// )
 
-var (
-	VegaSnapshotPath   = filepath.Join("state", "node", "snapshots")
-	VegaCoreConfigPath = filepath.Join("config", "node", "config.toml")
-	RemoteVegaPath     = "/home/vega/vegavisor_home/current/vega"
-)
+// var (
+// 	VegaSnapshotPath   = filepath.Join("state", "node", "snapshots")
+// 	VegaCoreConfigPath = filepath.Join("config", "node", "config.toml")
+// 	RemoteVegaPath     = "/home/vega/vegavisor_home/current/vega"
+// )
 
-type LoadSnapshotArgs struct {
-	*SnapshotCompatibilityArgs
+// type LoadSnapshotArgs struct {
+// 	*SnapshotCompatibilityArgs
 
-	VegacapsuleHome   string
-	VegacapsuleBinary string
-	VegaBinary        string
-	RemoteVegaBinary  string
+// 	VegacapsuleHome   string
+// 	VegacapsuleBinary string
+// 	VegaBinary        string
+// 	RemoteVegaBinary  string
 
-	SnapshotServerHost     string
-	SnapshotRemoteLocation string
-	SnapshotServerUser     string
-	SnapshotServerKeyFile  string
-}
+// 	SnapshotServerHost     string
+// 	SnapshotRemoteLocation string
+// 	SnapshotServerUser     string
+// 	SnapshotServerKeyFile  string
+// }
 
-func (args LoadSnapshotArgs) Check() error {
-	if _, err := vegacapsule.ListNodes(args.VegacapsuleBinary, args.VegacapsuleHome); err != nil {
-		return fmt.Errorf("no vegacapsule network generated: %w", err)
-	}
+// func (args LoadSnapshotArgs) Check() error {
+// 	if _, err := vegacapsule.ListNodes(args.VegacapsuleBinary, args.VegacapsuleHome); err != nil {
+// 		return fmt.Errorf("no vegacapsule network generated: %w", err)
+// 	}
 
-	version, err := tools.ExecuteBinary(args.VegaBinary, []string{"version"}, nil)
-	if err != nil {
-		return fmt.Errorf(
-			"failed to execute vega binary, try to provide a different binry with the --vega-binary flag: %s, %w",
-			version,
-			err,
-		)
-	}
+// 	version, err := tools.ExecuteBinary(args.VegaBinary, []string{"version"}, nil)
+// 	if err != nil {
+// 		return fmt.Errorf(
+// 			"failed to execute vega binary, try to provide a different binry with the --vega-binary flag: %s, %w",
+// 			version,
+// 			err,
+// 		)
+// 	}
 
-	if args.SnapshotServerHost == "" {
-		return fmt.Errorf(
-			"no snapshot server provided: provide value with the --snapshot-server flag",
-		)
-	}
+// 	if args.SnapshotServerHost == "" {
+// 		return fmt.Errorf(
+// 			"no snapshot server provided: provide value with the --snapshot-server flag",
+// 		)
+// 	}
 
-	if args.SnapshotRemoteLocation == "" {
-		return fmt.Errorf(
-			"snapshot remote locatino not provided: provide value with the --snapshot-remote-location flag",
-		)
-	}
+// 	if args.SnapshotRemoteLocation == "" {
+// 		return fmt.Errorf(
+// 			"snapshot remote locatino not provided: provide value with the --snapshot-remote-location flag",
+// 		)
+// 	}
 
-	if args.SnapshotServerUser == "" {
-		return fmt.Errorf(
-			"snapshot server user not provided: provide value with the --snapshot-server-user flag",
-		)
-	}
+// 	if args.SnapshotServerUser == "" {
+// 		return fmt.Errorf(
+// 			"snapshot server user not provided: provide value with the --snapshot-server-user flag",
+// 		)
+// 	}
 
-	if !tools.FileExists(args.SnapshotServerKeyFile) {
-		return fmt.Errorf(
-			"snapshot server key does not exist: provide value with the --snapshot-server-key flag",
-		)
-	}
+// 	if !tools.FileExists(args.SnapshotServerKeyFile) {
+// 		return fmt.Errorf(
+// 			"snapshot server key does not exist: provide value with the --snapshot-server-key flag",
+// 		)
+// 	}
 
-	return nil
-}
+// 	return nil
+// }
 
-var loadSnapshotArgs LoadSnapshotArgs
+// var loadSnapshotArgs LoadSnapshotArgs
 
-var loadSnapshotCmd = &cobra.Command{
-	Use:   "load-snapshot",
-	Short: "Download the snapshot from the mainnet and load it to local network",
-	Run: func(cmd *cobra.Command, args []string) {
-		if err := loadSnapshotArgs.Check(); err != nil {
-			loadSnapshotArgs.Logger.Fatal("invalid input", zap.Error(err))
-			return
-		}
+// var loadSnapshotCmd = &cobra.Command{
+// 	Use:   "load-snapshot",
+// 	Short: "Download the snapshot from the mainnet and load it to local network",
+// 	Run: func(cmd *cobra.Command, args []string) {
+// 		if err := loadSnapshotArgs.Check(); err != nil {
+// 			loadSnapshotArgs.Logger.Fatal("invalid input", zap.Error(err))
+// 			return
+// 		}
 
-		if err := runLoadSnapshot(loadSnapshotArgs.Logger,
-			loadSnapshotArgs.SnapshotServerHost,
-			loadSnapshotArgs.SnapshotServerUser,
-			loadSnapshotArgs.SnapshotServerKeyFile,
-			loadSnapshotArgs.SnapshotRemoteLocation,
-			loadSnapshotArgs.VegaBinary,
-			loadSnapshotArgs.RemoteVegaBinary,
-			loadSnapshotArgs.VegacapsuleBinary,
-			loadSnapshotArgs.VegacapsuleHome,
-		); err != nil {
-			loadSnapshotArgs.Logger.Fatal(
-				"failed to prepare for snapshot compatibility pipeline",
-				zap.Error(err),
-			)
-			return
-		}
-	},
-}
+// 		if err := runLoadSnapshot(loadSnapshotArgs.Logger,
+// 			loadSnapshotArgs.SnapshotServerHost,
+// 			loadSnapshotArgs.SnapshotServerUser,
+// 			loadSnapshotArgs.SnapshotServerKeyFile,
+// 			loadSnapshotArgs.SnapshotRemoteLocation,
+// 			loadSnapshotArgs.VegaBinary,
+// 			loadSnapshotArgs.RemoteVegaBinary,
+// 			loadSnapshotArgs.VegacapsuleBinary,
+// 			loadSnapshotArgs.VegacapsuleHome,
+// 		); err != nil {
+// 			loadSnapshotArgs.Logger.Fatal(
+// 				"failed to prepare for snapshot compatibility pipeline",
+// 				zap.Error(err),
+// 			)
+// 			return
+// 		}
+// 	},
+// }
 
-func init() {
-	loadSnapshotArgs.SnapshotCompatibilityArgs = &snapshotCompatibilityArgs
+// func init() {
+// 	loadSnapshotArgs.SnapshotCompatibilityArgs = &snapshotCompatibilityArgs
 
-	currentUser, _ := tools.WhoAmI()
-	loadSnapshotCmd.PersistentFlags().
-		StringVar(&loadSnapshotArgs.VegacapsuleHome, "vegacapsule-home", "", "The custom vegacapsule home")
-	loadSnapshotCmd.PersistentFlags().
-		StringVar(&loadSnapshotArgs.VegaBinary, "vega-binary", "vega", "Path to the vega executable on local machine")
-	loadSnapshotCmd.PersistentFlags().
-		StringVar(&loadSnapshotArgs.RemoteVegaBinary, "remote-vega-binary", RemoteVegaPath, "Path to the vega executable on remote machine")
-	loadSnapshotCmd.PersistentFlags().
-		StringVar(&loadSnapshotArgs.VegacapsuleBinary, "vegacapsule-binary", "vegacapsule", "Path to the vegacapsule executable")
-	loadSnapshotCmd.PersistentFlags().
-		StringVar(&loadSnapshotArgs.SnapshotServerHost, "snapshot-server", "", "The source server for the snapshot")
-	loadSnapshotCmd.PersistentFlags().
-		StringVar(&loadSnapshotArgs.SnapshotServerUser, "snapshot-server-user", currentUser, "The SSH user for the snapshot server")
-	loadSnapshotCmd.PersistentFlags().
-		StringVar(&loadSnapshotArgs.SnapshotRemoteLocation, "snapshot-remote-location", "/home/vega/vega_home/state/node/snapshots", "The location where the snapshot is on the remote server")
-	loadSnapshotCmd.PersistentFlags().
-		StringVar(&loadSnapshotArgs.SnapshotServerKeyFile, "snapshot-server-key-file", filepath.Join(tools.CurrentUserHomePath(), ".ssh", "id_rsa"), "The SSH private key used to authenticate user")
-}
+// 	currentUser, _ := tools.WhoAmI()
+// 	loadSnapshotCmd.PersistentFlags().
+// 		StringVar(&loadSnapshotArgs.VegacapsuleHome, "vegacapsule-home", "", "The custom vegacapsule home")
+// 	loadSnapshotCmd.PersistentFlags().
+// 		StringVar(&loadSnapshotArgs.VegaBinary, "vega-binary", "vega", "Path to the vega executable on local machine")
+// 	loadSnapshotCmd.PersistentFlags().
+// 		StringVar(&loadSnapshotArgs.RemoteVegaBinary, "remote-vega-binary", RemoteVegaPath, "Path to the vega executable on remote machine")
+// 	loadSnapshotCmd.PersistentFlags().
+// 		StringVar(&loadSnapshotArgs.VegacapsuleBinary, "vegacapsule-binary", "vegacapsule", "Path to the vegacapsule executable")
+// 	loadSnapshotCmd.PersistentFlags().
+// 		StringVar(&loadSnapshotArgs.SnapshotServerHost, "snapshot-server", "", "The source server for the snapshot")
+// 	loadSnapshotCmd.PersistentFlags().
+// 		StringVar(&loadSnapshotArgs.SnapshotServerUser, "snapshot-server-user", currentUser, "The SSH user for the snapshot server")
+// 	loadSnapshotCmd.PersistentFlags().
+// 		StringVar(&loadSnapshotArgs.SnapshotRemoteLocation, "snapshot-remote-location", "/home/vega/vega_home/state/node/snapshots", "The location where the snapshot is on the remote server")
+// 	loadSnapshotCmd.PersistentFlags().
+// 		StringVar(&loadSnapshotArgs.SnapshotServerKeyFile, "snapshot-server-key-file", filepath.Join(tools.CurrentUserHomePath(), ".ssh", "id_rsa"), "The SSH private key used to authenticate user")
+// }
 
-// TODO: Check vegacapule nodes and return list of all of the validators
-func vegacapsuleValidatorsCoreHomePaths(
-	vegacapsuleBinary, vegacapsuleHome string,
-) ([]string, error) {
-	result := []string{}
+// // TODO: Check vegacapule nodes and return list of all of the validators
+// func vegacapsuleValidatorsCoreHomePaths(
+// 	vegacapsuleBinary, vegacapsuleHome string,
+// ) ([]string, error) {
+// 	result := []string{}
 
-	nodes, err := vegacapsule.ListNodes(vegacapsuleBinary, vegacapsuleHome)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list vegacapsule nodes: %w", err)
-	}
+// 	nodes, err := vegacapsule.ListNodes(vegacapsuleBinary, vegacapsuleHome)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("failed to list vegacapsule nodes: %w", err)
+// 	}
 
-	for _, node := range nodes {
-		if node.Mode != vegacapsule.VegaModeValidator {
-			continue
-		}
-		result = append(result, node.Vega.HomeDir)
-	}
+// 	for _, node := range nodes {
+// 		if node.Mode != vegacapsule.VegaModeValidator {
+// 			continue
+// 		}
+// 		result = append(result, node.Vega.HomeDir)
+// 	}
 
-	return result, nil
-}
+// 	return result, nil
+// }
 
-func runLoadSnapshot(
-	logger *zap.Logger,
-	snapshotServerHost, snapshotServerUser, snapshotServerKeyFile, snapshotRemoteLocation string,
-	vegaBinary, RemoteVegaBinary, vegacapsuleBinary, vegacapsuleHome string,
-) error {
-	validatorHomePaths, err := vegacapsuleValidatorsCoreHomePaths(
-		vegacapsuleBinary,
-		vegacapsuleHome,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to get validator home paths: %w", err)
-	}
+// func runLoadSnapshot(
+// 	logger *zap.Logger,
+// 	snapshotServerHost, snapshotServerUser, snapshotServerKeyFile, snapshotRemoteLocation string,
+// 	vegaBinary, RemoteVegaBinary, vegacapsuleBinary, vegacapsuleHome string,
+// ) error {
+// 	validatorHomePaths, err := vegacapsuleValidatorsCoreHomePaths(
+// 		vegacapsuleBinary,
+// 		vegacapsuleHome,
+// 	)
+// 	if err != nil {
+// 		return fmt.Errorf("failed to get validator home paths: %w", err)
+// 	}
 
-	for _, validatorHomePath := range validatorHomePaths {
-		snapshotPath := filepath.Join(validatorHomePath, VegaSnapshotPath)
-		logger.Info(fmt.Sprintf("Creating folder for snapshot DB locally: %s", snapshotPath))
-		if err := os.MkdirAll(snapshotPath, os.ModePerm); err != nil {
-			return fmt.Errorf("failed to create snapshot db(%s): %w", snapshotPath, err)
-		}
-	}
+// 	for _, validatorHomePath := range validatorHomePaths {
+// 		snapshotPath := filepath.Join(validatorHomePath, VegaSnapshotPath)
+// 		logger.Info(fmt.Sprintf("Creating folder for snapshot DB locally: %s", snapshotPath))
+// 		if err := os.MkdirAll(snapshotPath, os.ModePerm); err != nil {
+// 			return fmt.Errorf("failed to create snapshot db(%s): %w", snapshotPath, err)
+// 		}
+// 	}
 
-	snapshotRemoteTempLocation := fmt.Sprintf("/tmp/snapshots-db-%d/snapshots", time.Now().UnixMicro())
+// 	snapshotRemoteTempLocation := fmt.Sprintf("/tmp/snapshots-db-%d/snapshots", time.Now().UnixMicro())
 
-	logger.Info("Creating SSH client",
-		zap.String("host", snapshotServerHost),
-		zap.String("user", snapshotServerUser),
-		zap.String("keyfile", snapshotServerKeyFile))
+// 	logger.Info("Creating SSH client",
+// 		zap.String("host", snapshotServerHost),
+// 		zap.String("user", snapshotServerUser),
+// 		zap.String("keyfile", snapshotServerKeyFile))
 
-	sshClient, err := ssh.GetSSHConnection(snapshotServerHost, snapshotServerUser, snapshotServerKeyFile)
-	if err != nil {
-		return fmt.Errorf("failed to create ssh connection client: %w", err)
-	}
+// 	sshClient, err := ssh.GetSSHConnection(snapshotServerHost, snapshotServerUser, snapshotServerKeyFile)
+// 	if err != nil {
+// 		return fmt.Errorf("failed to create ssh connection client: %w", err)
+// 	}
 
-	err = tools.RetryRun(3, 5*time.Second, func() error {
-		logger.Info("Trying to copy snapshot.db on remote server into temporary location")
-		return copySnapshotOnRemote(logger,
-			RemoteVegaBinary,
-			sshClient,
-			snapshotRemoteLocation,
-			snapshotRemoteTempLocation)
-	})
-	if err != nil {
-		return fmt.Errorf("failed to copy snapshot on remote temp location: %w", err)
-	}
-	defer remoteCleanup(logger, sshClient, filepath.Dir(snapshotRemoteTempLocation))
+// 	err = tools.RetryRun(3, 5*time.Second, func() error {
+// 		logger.Info("Trying to copy snapshot.db on remote server into temporary location")
+// 		return copySnapshotOnRemote(logger,
+// 			RemoteVegaBinary,
+// 			sshClient,
+// 			snapshotRemoteLocation,
+// 			snapshotRemoteTempLocation)
+// 	})
+// 	if err != nil {
+// 		return fmt.Errorf("failed to copy snapshot on remote temp location: %w", err)
+// 	}
+// 	defer remoteCleanup(logger, sshClient, filepath.Dir(snapshotRemoteTempLocation))
 
-	tempDir, err := os.MkdirTemp("", "devopstools-snapshot-compatibility")
-	if err != nil {
-		return fmt.Errorf("failed to create temporary dir to download snapshot db: %w", err)
-	}
-	defer os.RemoveAll(tempDir)
+// 	tempDir, err := os.MkdirTemp("", "devopstools-snapshot-compatibility")
+// 	if err != nil {
+// 		return fmt.Errorf("failed to create temporary dir to download snapshot db: %w", err)
+// 	}
+// 	defer os.RemoveAll(tempDir)
 
-	logger.Info(
-		"Downloading the snapshot db",
-		zap.String("server", fmt.Sprintf("%s@%s", snapshotServerUser, snapshotServerHost)),
-		zap.String("source path", snapshotRemoteTempLocation),
-		zap.String("destination", tempDir),
-	)
+// 	logger.Info(
+// 		"Downloading the snapshot db",
+// 		zap.String("server", fmt.Sprintf("%s@%s", snapshotServerUser, snapshotServerHost)),
+// 		zap.String("source path", snapshotRemoteTempLocation),
+// 		zap.String("destination", tempDir),
+// 	)
 
-	err = tools.RetryRun(3, 5*time.Second, func() error {
-		logger.Info("Trying to download snapshot-db")
-		return ssh.Download(
-			snapshotServerHost,
-			snapshotServerUser,
-			snapshotServerKeyFile,
-			snapshotRemoteTempLocation,
-			tempDir,
-			logger,
-		)
-	})
-	if err != nil {
-		return fmt.Errorf("failed to download snapshot db: %w", err)
-	}
-	logger.Info("Snapshot database downloaded")
+// 	err = tools.RetryRun(3, 5*time.Second, func() error {
+// 		logger.Info("Trying to download snapshot-db")
+// 		return ssh.Download(
+// 			snapshotServerHost,
+// 			snapshotServerUser,
+// 			snapshotServerKeyFile,
+// 			snapshotRemoteTempLocation,
+// 			tempDir,
+// 			logger,
+// 		)
+// 	})
+// 	if err != nil {
+// 		return fmt.Errorf("failed to download snapshot db: %w", err)
+// 	}
+// 	logger.Info("Snapshot database downloaded")
 
-	logger.Info("Selecting block height for the restart")
-	restartHeight, err := tools.RetryReturn(3, 5*time.Second, func() (int, error) {
-		return selectSnapshotHeight(vegaBinary, filepath.Join(tempDir, "snapshots"))
-	})
-	if err != nil {
-		return fmt.Errorf("failed to select height for network start: %w", err)
-	}
-	logger.Info("Selected height for restart", zap.Int("height", restartHeight))
+// 	logger.Info("Selecting block height for the restart")
+// 	restartHeight, err := tools.RetryReturn(3, 5*time.Second, func() (int, error) {
+// 		return selectSnapshotHeight(vegaBinary, filepath.Join(tempDir, "snapshots"))
+// 	})
+// 	if err != nil {
+// 		return fmt.Errorf("failed to select height for network start: %w", err)
+// 	}
+// 	logger.Info("Selected height for restart", zap.Int("height", restartHeight))
 
-	for _, validatorHomePath := range validatorHomePaths {
-		logger.Info(
-			"Updating core config",
-			zap.String("node_home", validatorHomePath),
-			zap.Int("height", restartHeight),
-		)
-		if err := updateCoreConfig(validatorHomePath, restartHeight); err != nil {
-			return fmt.Errorf(
-				"failed to update core config for node(%s): %w",
-				validatorHomePath,
-				err,
-			)
-		}
-		logger.Info("Config updated")
+// 	for _, validatorHomePath := range validatorHomePaths {
+// 		logger.Info(
+// 			"Updating core config",
+// 			zap.String("node_home", validatorHomePath),
+// 			zap.Int("height", restartHeight),
+// 		)
+// 		if err := updateCoreConfig(validatorHomePath, restartHeight); err != nil {
+// 			return fmt.Errorf(
+// 				"failed to update core config for node(%s): %w",
+// 				validatorHomePath,
+// 				err,
+// 			)
+// 		}
+// 		logger.Info("Config updated")
 
-		snapshotDestination := filepath.Join(validatorHomePath, VegaSnapshotPath)
-		snapshotSource := filepath.Join(tempDir, "snapshots")
+// 		snapshotDestination := filepath.Join(validatorHomePath, VegaSnapshotPath)
+// 		snapshotSource := filepath.Join(tempDir, "snapshots")
 
-		logger.Info("Calling unsafe reset all for core", zap.String("node", validatorHomePath))
-		if _, err := tools.ExecuteBinary(vegaBinary, []string{"unsafe_reset_all", "--home", validatorHomePath}, nil); err != nil {
-			return fmt.Errorf("failed to unsafe reset all for home %s: %w", validatorHomePath, err)
-		}
-		logger.Info("Unsafe reset all successful")
+// 		logger.Info("Calling unsafe reset all for core", zap.String("node", validatorHomePath))
+// 		if _, err := tools.ExecuteBinary(vegaBinary, []string{"unsafe_reset_all", "--home", validatorHomePath}, nil); err != nil {
+// 			return fmt.Errorf("failed to unsafe reset all for home %s: %w", validatorHomePath, err)
+// 		}
+// 		logger.Info("Unsafe reset all successful")
 
-		logger.Info(
-			"Loading snapshot database into the core node",
-			zap.String("source", snapshotSource),
-			zap.String("destination", snapshotDestination),
-		)
+// 		logger.Info(
+// 			"Loading snapshot database into the core node",
+// 			zap.String("source", snapshotSource),
+// 			zap.String("destination", snapshotDestination),
+// 		)
 
-		if err := tools.CopyDir(snapshotSource, snapshotDestination); err != nil {
-			return fmt.Errorf(
-				"failed to copy snapshot from temporary location to node %s: %w",
-				snapshotDestination,
-				err,
-			)
-		}
+// 		if err := tools.CopyDir(snapshotSource, snapshotDestination); err != nil {
+// 			return fmt.Errorf(
+// 				"failed to copy snapshot from temporary location to node %s: %w",
+// 				snapshotDestination,
+// 				err,
+// 			)
+// 		}
 
-		logger.Info("Snapshot database loaded")
-	}
-	return nil
-}
+// 		logger.Info("Snapshot database loaded")
+// 	}
+// 	return nil
+// }
 
-func remoteCleanup(logger *zap.Logger, sshClient *sshlib.Client, filePath string) error {
-	cleanupCommand := fmt.Sprintf("rm -fr %s || echo 'OK'", filePath)
-	logger.Info("Cleaning the remote server up",
-		zap.String("filepath", filePath))
+// func remoteCleanup(logger *zap.Logger, sshClient *sshlib.Client, filePath string) error {
+// 	cleanupCommand := fmt.Sprintf("rm -fr %s || echo 'OK'", filePath)
+// 	logger.Info("Cleaning the remote server up",
+// 		zap.String("filepath", filePath))
 
-	if stdout, err := ssh.RunCommandWithClient(sshClient, cleanupCommand); err != nil {
-		return fmt.Errorf("failed to cleanup on remote: output: %s: %s", stdout, err)
-	}
+// 	if stdout, err := ssh.RunCommandWithClient(sshClient, cleanupCommand); err != nil {
+// 		return fmt.Errorf("failed to cleanup on remote: output: %s: %s", stdout, err)
+// 	}
 
-	return nil
-}
+// 	return nil
+// }
 
-func copySnapshotOnRemote(logger *zap.Logger,
-	RemoteVegaBinary string,
-	sshClient *sshlib.Client,
-	source, destination string,
-) error {
-	cleanupCommand := fmt.Sprintf("rm -fr %s || echo 'OK'", destination)
-	logger.Info("Cleaning the destination up",
-		zap.String("filepath", destination))
+// func copySnapshotOnRemote(logger *zap.Logger,
+// 	RemoteVegaBinary string,
+// 	sshClient *sshlib.Client,
+// 	source, destination string,
+// ) error {
+// 	cleanupCommand := fmt.Sprintf("rm -fr %s || echo 'OK'", destination)
+// 	logger.Info("Cleaning the destination up",
+// 		zap.String("filepath", destination))
 
-	if stdout, err := ssh.RunCommandWithClient(sshClient, cleanupCommand); err != nil {
-		logger.Error(
-			"failed to cleanup on remote",
-			zap.String("stdout", stdout),
-			zap.Error(err),
-		)
-		return fmt.Errorf("failed to cleanup on remote: output: %s: %s", stdout, err)
-	}
+// 	if stdout, err := ssh.RunCommandWithClient(sshClient, cleanupCommand); err != nil {
+// 		logger.Error(
+// 			"failed to cleanup on remote",
+// 			zap.String("stdout", stdout),
+// 			zap.Error(err),
+// 		)
+// 		return fmt.Errorf("failed to cleanup on remote: output: %s: %s", stdout, err)
+// 	}
 
-	mkdirCommand := fmt.Sprintf("mkdir -p %s", filepath.Dir(destination))
-	logger.Info("Ensuring destination directory exists",
-		zap.String("command", mkdirCommand))
+// 	mkdirCommand := fmt.Sprintf("mkdir -p %s", filepath.Dir(destination))
+// 	logger.Info("Ensuring destination directory exists",
+// 		zap.String("command", mkdirCommand))
 
-	if stdout, err := ssh.RunCommandWithClient(sshClient, mkdirCommand); err != nil {
-		logger.Error(
-			"failed to ensure destination directory exists",
-			zap.String("stdout", stdout),
-			zap.Error(err),
-		)
-		return fmt.Errorf("failed to ensure destination directory exists: output: %s: %s", stdout, err)
-	}
+// 	if stdout, err := ssh.RunCommandWithClient(sshClient, mkdirCommand); err != nil {
+// 		logger.Error(
+// 			"failed to ensure destination directory exists",
+// 			zap.String("stdout", stdout),
+// 			zap.Error(err),
+// 		)
+// 		return fmt.Errorf("failed to ensure destination directory exists: output: %s: %s", stdout, err)
+// 	}
 
-	copyCommand := fmt.Sprintf("cp -r %s %s", source, destination)
+// 	copyCommand := fmt.Sprintf("cp -r %s %s", source, destination)
 
-	logger.Info("Copying snapshot db to temp location",
-		zap.String("command", copyCommand))
-	if stdout, err := ssh.RunCommandWithClient(sshClient, copyCommand); err != nil {
-		logger.Error(
-			fmt.Sprintf("failed to copy snapshot from %s to %s on remote: output", source, destination),
-			zap.String("stdout", stdout),
-			zap.Error(err),
-		)
-		return fmt.Errorf("failed to copy snapshot from %s to %s on remote: output: %s: %s", source, destination, stdout, err)
-	}
+// 	logger.Info("Copying snapshot db to temp location",
+// 		zap.String("command", copyCommand))
+// 	if stdout, err := ssh.RunCommandWithClient(sshClient, copyCommand); err != nil {
+// 		logger.Error(
+// 			fmt.Sprintf("failed to copy snapshot from %s to %s on remote: output", source, destination),
+// 			zap.String("stdout", stdout),
+// 			zap.Error(err),
+// 		)
+// 		return fmt.Errorf("failed to copy snapshot from %s to %s on remote: output: %s: %s", source, destination, stdout, err)
+// 	}
 
-	checkCommand := fmt.Sprintf("%s tools snapshot --db-path '%s'", RemoteVegaBinary, destination)
-	logger.Info("Checking if copied snapshot was copied correctly",
-		zap.String("command", checkCommand))
-	if stdout, err := ssh.RunCommandWithClient(sshClient, checkCommand); err != nil {
-		logger.Error(
-			"failed to check if snapshot was correctly copied on remote",
-			zap.String("stdout", stdout),
-			zap.Error(err),
-		)
-		return fmt.Errorf("failed to check if snapshot was correctly copied on remote: output: %s: %w", stdout, err)
-	}
+// 	checkCommand := fmt.Sprintf("%s tools snapshot --db-path '%s'", RemoteVegaBinary, destination)
+// 	logger.Info("Checking if copied snapshot was copied correctly",
+// 		zap.String("command", checkCommand))
+// 	if stdout, err := ssh.RunCommandWithClient(sshClient, checkCommand); err != nil {
+// 		logger.Error(
+// 			"failed to check if snapshot was correctly copied on remote",
+// 			zap.String("stdout", stdout),
+// 			zap.Error(err),
+// 		)
+// 		return fmt.Errorf("failed to check if snapshot was correctly copied on remote: output: %s: %w", stdout, err)
+// 	}
 
-	return nil
-}
+// 	return nil
+// }
 
-func selectSnapshotHeight(vegaBinary, snapshotDbLocation string) (int, error) {
-	snapshotsResponse, err := vegacmd.ListCoreSnapshots(
-		vegaBinary,
-		vegacmd.CoreSnashotInput{SnapshotDbPath: snapshotDbLocation},
-	)
-	if err != nil {
-		return 0, fmt.Errorf("failed to list core snapshots: %w", err)
-	}
+// func selectSnapshotHeight(vegaBinary, snapshotDbLocation string) (int, error) {
+// 	snapshotsResponse, err := vegacmd.ListCoreSnapshots(
+// 		vegaBinary,
+// 		vegacmd.CoreSnashotInput{SnapshotDbPath: snapshotDbLocation},
+// 	)
+// 	if err != nil {
+// 		return 0, fmt.Errorf("failed to list core snapshots: %w", err)
+// 	}
 
-	snapshotList := snapshotsResponse.Snapshots
-	sort.Slice(snapshotList, func(i, j int) bool {
-		return snapshotList[i].Height > snapshotList[j].Height
-	})
-	if len(snapshotList) < 1 {
-		return 0, fmt.Errorf(
-			"not enough snapshots: expected at least 1 snapshots, %d got",
-			len(snapshotList),
-		)
-	}
-	return snapshotList[0].Height, nil
-}
+// 	snapshotList := snapshotsResponse.Snapshots
+// 	sort.Slice(snapshotList, func(i, j int) bool {
+// 		return snapshotList[i].Height > snapshotList[j].Height
+// 	})
+// 	if len(snapshotList) < 1 {
+// 		return 0, fmt.Errorf(
+// 			"not enough snapshots: expected at least 1 snapshots, %d got",
+// 			len(snapshotList),
+// 		)
+// 	}
+// 	return snapshotList[0].Height, nil
+// }
 
-func updateCoreConfig(coreHome string, startHeight int) error {
-	configPath := filepath.Join(coreHome, VegaCoreConfigPath)
-	coreConfigNode, err := dasel.NewFromFile(configPath, "toml")
-	if err != nil {
-		return fmt.Errorf("failed to read core config: %w", err)
-	}
-	if err := coreConfigNode.Put("Snapshot.StartHeight", startHeight); err != nil {
-		return fmt.Errorf("failed to set Snapshot.StartHeight in the vega node config: %w", err)
-	}
-	if err := coreConfigNode.WriteToFile(configPath, "toml", []storage.ReadWriteOption{}); err != nil {
-		return fmt.Errorf("failed to write the %s file: %w", configPath, err)
-	}
+// func updateCoreConfig(coreHome string, startHeight int) error {
+// 	configPath := filepath.Join(coreHome, VegaCoreConfigPath)
+// 	coreConfigNode, err := dasel.NewFromFile(configPath, "toml")
+// 	if err != nil {
+// 		return fmt.Errorf("failed to read core config: %w", err)
+// 	}
+// 	if err := coreConfigNode.Put("Snapshot.StartHeight", startHeight); err != nil {
+// 		return fmt.Errorf("failed to set Snapshot.StartHeight in the vega node config: %w", err)
+// 	}
+// 	if err := coreConfigNode.WriteToFile(configPath, "toml", []storage.ReadWriteOption{}); err != nil {
+// 		return fmt.Errorf("failed to write the %s file: %w", configPath, err)
+// 	}
 
-	return nil
-}
+// 	return nil
+// }

--- a/cmd/snapshotcompatibility/load-snapshot.go
+++ b/cmd/snapshotcompatibility/load-snapshot.go
@@ -1,390 +1,219 @@
 package snapshotcompatibility
 
-// import (
-// 	"fmt"
-// 	"os"
-// 	"path/filepath"
-// 	"sort"
-// 	"time"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
 
-// 	"github.com/spf13/cobra"
-// 	"github.com/tomwright/dasel"
-// 	"github.com/tomwright/dasel/storage"
-// 	"go.uber.org/zap"
-// 	sshlib "golang.org/x/crypto/ssh"
+	"github.com/spf13/cobra"
+	"github.com/tomwright/dasel"
+	"github.com/tomwright/dasel/storage"
+	"go.uber.org/zap"
 
-// 	"github.com/vegaprotocol/devopstools/ssh"
-// 	"github.com/vegaprotocol/devopstools/tools"
-// 	"github.com/vegaprotocol/devopstools/vegacapsule"
-// 	"github.com/vegaprotocol/devopstools/vegacmd"
-// )
+	"github.com/vegaprotocol/devopstools/tools"
+	"github.com/vegaprotocol/devopstools/vegacapsule"
+	"github.com/vegaprotocol/devopstools/vegacmd"
+)
 
-// var (
-// 	VegaSnapshotPath   = filepath.Join("state", "node", "snapshots")
-// 	VegaCoreConfigPath = filepath.Join("config", "node", "config.toml")
-// 	RemoteVegaPath     = "/home/vega/vegavisor_home/current/vega"
-// )
+type LoadSnapshotArgs struct {
+	*SnapshotCompatibilityArgs
 
-// type LoadSnapshotArgs struct {
-// 	*SnapshotCompatibilityArgs
+	VegacapsuleHome   string
+	VegacapsuleBinary string
+	VegaBinary        string
+	SnapshotLocation  string
+}
 
-// 	VegacapsuleHome   string
-// 	VegacapsuleBinary string
-// 	VegaBinary        string
-// 	RemoteVegaBinary  string
+func (args LoadSnapshotArgs) Check() error {
+	if _, err := vegacapsule.ListNodes(args.VegacapsuleBinary, args.VegacapsuleHome); err != nil {
+		return fmt.Errorf("no vegacapsule network generated: %w", err)
+	}
 
-// 	SnapshotServerHost     string
-// 	SnapshotRemoteLocation string
-// 	SnapshotServerUser     string
-// 	SnapshotServerKeyFile  string
-// }
+	version, err := tools.ExecuteBinary(args.VegaBinary, []string{"version"}, nil)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to execute vega binary, try to provide a different binry with the --vega-binary flag: %s, %w",
+			version,
+			err,
+		)
+	}
 
-// func (args LoadSnapshotArgs) Check() error {
-// 	if _, err := vegacapsule.ListNodes(args.VegacapsuleBinary, args.VegacapsuleHome); err != nil {
-// 		return fmt.Errorf("no vegacapsule network generated: %w", err)
-// 	}
+	if !tools.FileExists(args.SnapshotLocation) {
+		return fmt.Errorf("cannot find downloaded mainnet snapshot in %s", args.SnapshotLocation)
+	}
 
-// 	version, err := tools.ExecuteBinary(args.VegaBinary, []string{"version"}, nil)
-// 	if err != nil {
-// 		return fmt.Errorf(
-// 			"failed to execute vega binary, try to provide a different binry with the --vega-binary flag: %s, %w",
-// 			version,
-// 			err,
-// 		)
-// 	}
+	return nil
+}
 
-// 	if args.SnapshotServerHost == "" {
-// 		return fmt.Errorf(
-// 			"no snapshot server provided: provide value with the --snapshot-server flag",
-// 		)
-// 	}
+var loadSnapshotArgs LoadSnapshotArgs
 
-// 	if args.SnapshotRemoteLocation == "" {
-// 		return fmt.Errorf(
-// 			"snapshot remote locatino not provided: provide value with the --snapshot-remote-location flag",
-// 		)
-// 	}
+var loadSnapshotCmd = &cobra.Command{
+	Use:   "load-snapshot",
+	Short: "Download the snapshot from the mainnet and load it to local network",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := loadSnapshotArgs.Check(); err != nil {
+			loadSnapshotArgs.Logger.Fatal("invalid input", zap.Error(err))
+			return
+		}
 
-// 	if args.SnapshotServerUser == "" {
-// 		return fmt.Errorf(
-// 			"snapshot server user not provided: provide value with the --snapshot-server-user flag",
-// 		)
-// 	}
+		if err := runLoadSnapshot(loadSnapshotArgs.Logger,
+			loadSnapshotArgs.SnapshotLocation,
+			loadSnapshotArgs.VegaBinary,
+			loadSnapshotArgs.VegacapsuleBinary,
+			loadSnapshotArgs.VegacapsuleHome,
+		); err != nil {
+			loadSnapshotArgs.Logger.Fatal(
+				"failed to prepare for snapshot compatibility pipeline",
+				zap.Error(err),
+			)
+			return
+		}
+	},
+}
 
-// 	if !tools.FileExists(args.SnapshotServerKeyFile) {
-// 		return fmt.Errorf(
-// 			"snapshot server key does not exist: provide value with the --snapshot-server-key flag",
-// 		)
-// 	}
+func init() {
+	loadSnapshotArgs.SnapshotCompatibilityArgs = &snapshotCompatibilityArgs
 
-// 	return nil
-// }
+	loadSnapshotCmd.PersistentFlags().
+		StringVar(&loadSnapshotArgs.VegacapsuleHome, "vegacapsule-home", "", "The custom vegacapsule home")
+	loadSnapshotCmd.PersistentFlags().
+		StringVar(&loadSnapshotArgs.VegaBinary, "vega-binary", "vega", "Path to the vega executable on local machine")
+	loadSnapshotCmd.PersistentFlags().
+		StringVar(&loadSnapshotArgs.SnapshotLocation, "snapshot-location", "/tmp/mainnet-snapshot", "Path to the downloaded snapshot from mainnet server")
+	loadSnapshotCmd.PersistentFlags().
+		StringVar(&loadSnapshotArgs.VegacapsuleBinary, "vegacapsule-binary", "vegacapsule", "Path to the vegacapsule executable")
+}
 
-// var loadSnapshotArgs LoadSnapshotArgs
+// TODO: Check vegacapule nodes and return list of all of the validators
+func vegacapsuleValidatorsCoreHomePaths(
+	vegacapsuleBinary, vegacapsuleHome string,
+) ([]string, error) {
+	result := []string{}
 
-// var loadSnapshotCmd = &cobra.Command{
-// 	Use:   "load-snapshot",
-// 	Short: "Download the snapshot from the mainnet and load it to local network",
-// 	Run: func(cmd *cobra.Command, args []string) {
-// 		if err := loadSnapshotArgs.Check(); err != nil {
-// 			loadSnapshotArgs.Logger.Fatal("invalid input", zap.Error(err))
-// 			return
-// 		}
+	nodes, err := vegacapsule.ListNodes(vegacapsuleBinary, vegacapsuleHome)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list vegacapsule nodes: %w", err)
+	}
 
-// 		if err := runLoadSnapshot(loadSnapshotArgs.Logger,
-// 			loadSnapshotArgs.SnapshotServerHost,
-// 			loadSnapshotArgs.SnapshotServerUser,
-// 			loadSnapshotArgs.SnapshotServerKeyFile,
-// 			loadSnapshotArgs.SnapshotRemoteLocation,
-// 			loadSnapshotArgs.VegaBinary,
-// 			loadSnapshotArgs.RemoteVegaBinary,
-// 			loadSnapshotArgs.VegacapsuleBinary,
-// 			loadSnapshotArgs.VegacapsuleHome,
-// 		); err != nil {
-// 			loadSnapshotArgs.Logger.Fatal(
-// 				"failed to prepare for snapshot compatibility pipeline",
-// 				zap.Error(err),
-// 			)
-// 			return
-// 		}
-// 	},
-// }
+	for _, node := range nodes {
+		if node.Mode != vegacapsule.VegaModeValidator {
+			continue
+		}
+		result = append(result, node.Vega.HomeDir)
+	}
 
-// func init() {
-// 	loadSnapshotArgs.SnapshotCompatibilityArgs = &snapshotCompatibilityArgs
+	return result, nil
+}
 
-// 	currentUser, _ := tools.WhoAmI()
-// 	loadSnapshotCmd.PersistentFlags().
-// 		StringVar(&loadSnapshotArgs.VegacapsuleHome, "vegacapsule-home", "", "The custom vegacapsule home")
-// 	loadSnapshotCmd.PersistentFlags().
-// 		StringVar(&loadSnapshotArgs.VegaBinary, "vega-binary", "vega", "Path to the vega executable on local machine")
-// 	loadSnapshotCmd.PersistentFlags().
-// 		StringVar(&loadSnapshotArgs.RemoteVegaBinary, "remote-vega-binary", RemoteVegaPath, "Path to the vega executable on remote machine")
-// 	loadSnapshotCmd.PersistentFlags().
-// 		StringVar(&loadSnapshotArgs.VegacapsuleBinary, "vegacapsule-binary", "vegacapsule", "Path to the vegacapsule executable")
-// 	loadSnapshotCmd.PersistentFlags().
-// 		StringVar(&loadSnapshotArgs.SnapshotServerHost, "snapshot-server", "", "The source server for the snapshot")
-// 	loadSnapshotCmd.PersistentFlags().
-// 		StringVar(&loadSnapshotArgs.SnapshotServerUser, "snapshot-server-user", currentUser, "The SSH user for the snapshot server")
-// 	loadSnapshotCmd.PersistentFlags().
-// 		StringVar(&loadSnapshotArgs.SnapshotRemoteLocation, "snapshot-remote-location", "/home/vega/vega_home/state/node/snapshots", "The location where the snapshot is on the remote server")
-// 	loadSnapshotCmd.PersistentFlags().
-// 		StringVar(&loadSnapshotArgs.SnapshotServerKeyFile, "snapshot-server-key-file", filepath.Join(tools.CurrentUserHomePath(), ".ssh", "id_rsa"), "The SSH private key used to authenticate user")
-// }
+func runLoadSnapshot(
+	logger *zap.Logger,
+	snapshotLocation string,
+	vegaBinary, vegacapsuleBinary, vegacapsuleHome string,
+) error {
+	validatorHomePaths, err := vegacapsuleValidatorsCoreHomePaths(
+		vegacapsuleBinary,
+		vegacapsuleHome,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to get validator home paths: %w", err)
+	}
 
-// // TODO: Check vegacapule nodes and return list of all of the validators
-// func vegacapsuleValidatorsCoreHomePaths(
-// 	vegacapsuleBinary, vegacapsuleHome string,
-// ) ([]string, error) {
-// 	result := []string{}
+	for _, validatorHomePath := range validatorHomePaths {
+		snapshotPath := filepath.Join(validatorHomePath, VegaSnapshotPath)
+		logger.Info(fmt.Sprintf("Creating folder for snapshot DB locally: %s", snapshotPath))
+		if err := os.MkdirAll(snapshotPath, os.ModePerm); err != nil {
+			return fmt.Errorf("failed to create snapshot db(%s): %w", snapshotPath, err)
+		}
+	}
 
-// 	nodes, err := vegacapsule.ListNodes(vegacapsuleBinary, vegacapsuleHome)
-// 	if err != nil {
-// 		return nil, fmt.Errorf("failed to list vegacapsule nodes: %w", err)
-// 	}
+	logger.Info("Selecting block height for the restart")
+	restartHeight, err := tools.RetryReturn(3, 5*time.Second, func() (int, error) {
+		return selectSnapshotHeight(vegaBinary, filepath.Join(snapshotLocation, "snapshots"))
+	})
+	if err != nil {
+		return fmt.Errorf("failed to select height for network start: %w", err)
+	}
+	logger.Info("Selected height for restart", zap.Int("height", restartHeight))
 
-// 	for _, node := range nodes {
-// 		if node.Mode != vegacapsule.VegaModeValidator {
-// 			continue
-// 		}
-// 		result = append(result, node.Vega.HomeDir)
-// 	}
+	for _, validatorHomePath := range validatorHomePaths {
+		logger.Info(
+			"Updating core config",
+			zap.String("node_home", validatorHomePath),
+			zap.Int("height", restartHeight),
+		)
+		if err := updateCoreConfig(validatorHomePath, restartHeight); err != nil {
+			return fmt.Errorf(
+				"failed to update core config for node(%s): %w",
+				validatorHomePath,
+				err,
+			)
+		}
+		logger.Info("Config updated")
 
-// 	return result, nil
-// }
+		snapshotDestination := filepath.Join(validatorHomePath, VegaSnapshotPath)
+		snapshotSource := filepath.Join(snapshotLocation, "snapshots")
 
-// func runLoadSnapshot(
-// 	logger *zap.Logger,
-// 	snapshotServerHost, snapshotServerUser, snapshotServerKeyFile, snapshotRemoteLocation string,
-// 	vegaBinary, RemoteVegaBinary, vegacapsuleBinary, vegacapsuleHome string,
-// ) error {
-// 	validatorHomePaths, err := vegacapsuleValidatorsCoreHomePaths(
-// 		vegacapsuleBinary,
-// 		vegacapsuleHome,
-// 	)
-// 	if err != nil {
-// 		return fmt.Errorf("failed to get validator home paths: %w", err)
-// 	}
+		logger.Info("Calling unsafe reset all for core", zap.String("node", validatorHomePath))
+		if _, err := tools.ExecuteBinary(vegaBinary, []string{"unsafe_reset_all", "--home", validatorHomePath}, nil); err != nil {
+			return fmt.Errorf("failed to unsafe reset all for home %s: %w", validatorHomePath, err)
+		}
+		logger.Info("Unsafe reset all successful")
 
-// 	for _, validatorHomePath := range validatorHomePaths {
-// 		snapshotPath := filepath.Join(validatorHomePath, VegaSnapshotPath)
-// 		logger.Info(fmt.Sprintf("Creating folder for snapshot DB locally: %s", snapshotPath))
-// 		if err := os.MkdirAll(snapshotPath, os.ModePerm); err != nil {
-// 			return fmt.Errorf("failed to create snapshot db(%s): %w", snapshotPath, err)
-// 		}
-// 	}
+		logger.Info(
+			"Loading snapshot database into the core node",
+			zap.String("source", snapshotSource),
+			zap.String("destination", snapshotDestination),
+		)
 
-// 	snapshotRemoteTempLocation := fmt.Sprintf("/tmp/snapshots-db-%d/snapshots", time.Now().UnixMicro())
+		if err := tools.CopyDir(snapshotSource, snapshotDestination); err != nil {
+			return fmt.Errorf(
+				"failed to copy snapshot from temporary location to node %s: %w",
+				snapshotDestination,
+				err,
+			)
+		}
 
-// 	logger.Info("Creating SSH client",
-// 		zap.String("host", snapshotServerHost),
-// 		zap.String("user", snapshotServerUser),
-// 		zap.String("keyfile", snapshotServerKeyFile))
+		logger.Info("Snapshot database loaded")
+	}
+	return nil
+}
 
-// 	sshClient, err := ssh.GetSSHConnection(snapshotServerHost, snapshotServerUser, snapshotServerKeyFile)
-// 	if err != nil {
-// 		return fmt.Errorf("failed to create ssh connection client: %w", err)
-// 	}
+func selectSnapshotHeight(vegaBinary, snapshotDbLocation string) (int, error) {
+	snapshotsResponse, err := vegacmd.ListCoreSnapshots(
+		vegaBinary,
+		vegacmd.CoreSnashotInput{SnapshotDbPath: snapshotDbLocation},
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to list core snapshots: %w", err)
+	}
 
-// 	err = tools.RetryRun(3, 5*time.Second, func() error {
-// 		logger.Info("Trying to copy snapshot.db on remote server into temporary location")
-// 		return copySnapshotOnRemote(logger,
-// 			RemoteVegaBinary,
-// 			sshClient,
-// 			snapshotRemoteLocation,
-// 			snapshotRemoteTempLocation)
-// 	})
-// 	if err != nil {
-// 		return fmt.Errorf("failed to copy snapshot on remote temp location: %w", err)
-// 	}
-// 	defer remoteCleanup(logger, sshClient, filepath.Dir(snapshotRemoteTempLocation))
+	snapshotList := snapshotsResponse.Snapshots
+	sort.Slice(snapshotList, func(i, j int) bool {
+		return snapshotList[i].Height > snapshotList[j].Height
+	})
+	if len(snapshotList) < 1 {
+		return 0, fmt.Errorf(
+			"not enough snapshots: expected at least 1 snapshots, %d got",
+			len(snapshotList),
+		)
+	}
+	return snapshotList[0].Height, nil
+}
 
-// 	tempDir, err := os.MkdirTemp("", "devopstools-snapshot-compatibility")
-// 	if err != nil {
-// 		return fmt.Errorf("failed to create temporary dir to download snapshot db: %w", err)
-// 	}
-// 	defer os.RemoveAll(tempDir)
+func updateCoreConfig(coreHome string, startHeight int) error {
+	configPath := filepath.Join(coreHome, VegaCoreConfigPath)
+	coreConfigNode, err := dasel.NewFromFile(configPath, "toml")
+	if err != nil {
+		return fmt.Errorf("failed to read core config: %w", err)
+	}
+	if err := coreConfigNode.Put("Snapshot.StartHeight", startHeight); err != nil {
+		return fmt.Errorf("failed to set Snapshot.StartHeight in the vega node config: %w", err)
+	}
+	if err := coreConfigNode.WriteToFile(configPath, "toml", []storage.ReadWriteOption{}); err != nil {
+		return fmt.Errorf("failed to write the %s file: %w", configPath, err)
+	}
 
-// 	logger.Info(
-// 		"Downloading the snapshot db",
-// 		zap.String("server", fmt.Sprintf("%s@%s", snapshotServerUser, snapshotServerHost)),
-// 		zap.String("source path", snapshotRemoteTempLocation),
-// 		zap.String("destination", tempDir),
-// 	)
-
-// 	err = tools.RetryRun(3, 5*time.Second, func() error {
-// 		logger.Info("Trying to download snapshot-db")
-// 		return ssh.Download(
-// 			snapshotServerHost,
-// 			snapshotServerUser,
-// 			snapshotServerKeyFile,
-// 			snapshotRemoteTempLocation,
-// 			tempDir,
-// 			logger,
-// 		)
-// 	})
-// 	if err != nil {
-// 		return fmt.Errorf("failed to download snapshot db: %w", err)
-// 	}
-// 	logger.Info("Snapshot database downloaded")
-
-// 	logger.Info("Selecting block height for the restart")
-// 	restartHeight, err := tools.RetryReturn(3, 5*time.Second, func() (int, error) {
-// 		return selectSnapshotHeight(vegaBinary, filepath.Join(tempDir, "snapshots"))
-// 	})
-// 	if err != nil {
-// 		return fmt.Errorf("failed to select height for network start: %w", err)
-// 	}
-// 	logger.Info("Selected height for restart", zap.Int("height", restartHeight))
-
-// 	for _, validatorHomePath := range validatorHomePaths {
-// 		logger.Info(
-// 			"Updating core config",
-// 			zap.String("node_home", validatorHomePath),
-// 			zap.Int("height", restartHeight),
-// 		)
-// 		if err := updateCoreConfig(validatorHomePath, restartHeight); err != nil {
-// 			return fmt.Errorf(
-// 				"failed to update core config for node(%s): %w",
-// 				validatorHomePath,
-// 				err,
-// 			)
-// 		}
-// 		logger.Info("Config updated")
-
-// 		snapshotDestination := filepath.Join(validatorHomePath, VegaSnapshotPath)
-// 		snapshotSource := filepath.Join(tempDir, "snapshots")
-
-// 		logger.Info("Calling unsafe reset all for core", zap.String("node", validatorHomePath))
-// 		if _, err := tools.ExecuteBinary(vegaBinary, []string{"unsafe_reset_all", "--home", validatorHomePath}, nil); err != nil {
-// 			return fmt.Errorf("failed to unsafe reset all for home %s: %w", validatorHomePath, err)
-// 		}
-// 		logger.Info("Unsafe reset all successful")
-
-// 		logger.Info(
-// 			"Loading snapshot database into the core node",
-// 			zap.String("source", snapshotSource),
-// 			zap.String("destination", snapshotDestination),
-// 		)
-
-// 		if err := tools.CopyDir(snapshotSource, snapshotDestination); err != nil {
-// 			return fmt.Errorf(
-// 				"failed to copy snapshot from temporary location to node %s: %w",
-// 				snapshotDestination,
-// 				err,
-// 			)
-// 		}
-
-// 		logger.Info("Snapshot database loaded")
-// 	}
-// 	return nil
-// }
-
-// func remoteCleanup(logger *zap.Logger, sshClient *sshlib.Client, filePath string) error {
-// 	cleanupCommand := fmt.Sprintf("rm -fr %s || echo 'OK'", filePath)
-// 	logger.Info("Cleaning the remote server up",
-// 		zap.String("filepath", filePath))
-
-// 	if stdout, err := ssh.RunCommandWithClient(sshClient, cleanupCommand); err != nil {
-// 		return fmt.Errorf("failed to cleanup on remote: output: %s: %s", stdout, err)
-// 	}
-
-// 	return nil
-// }
-
-// func copySnapshotOnRemote(logger *zap.Logger,
-// 	RemoteVegaBinary string,
-// 	sshClient *sshlib.Client,
-// 	source, destination string,
-// ) error {
-// 	cleanupCommand := fmt.Sprintf("rm -fr %s || echo 'OK'", destination)
-// 	logger.Info("Cleaning the destination up",
-// 		zap.String("filepath", destination))
-
-// 	if stdout, err := ssh.RunCommandWithClient(sshClient, cleanupCommand); err != nil {
-// 		logger.Error(
-// 			"failed to cleanup on remote",
-// 			zap.String("stdout", stdout),
-// 			zap.Error(err),
-// 		)
-// 		return fmt.Errorf("failed to cleanup on remote: output: %s: %s", stdout, err)
-// 	}
-
-// 	mkdirCommand := fmt.Sprintf("mkdir -p %s", filepath.Dir(destination))
-// 	logger.Info("Ensuring destination directory exists",
-// 		zap.String("command", mkdirCommand))
-
-// 	if stdout, err := ssh.RunCommandWithClient(sshClient, mkdirCommand); err != nil {
-// 		logger.Error(
-// 			"failed to ensure destination directory exists",
-// 			zap.String("stdout", stdout),
-// 			zap.Error(err),
-// 		)
-// 		return fmt.Errorf("failed to ensure destination directory exists: output: %s: %s", stdout, err)
-// 	}
-
-// 	copyCommand := fmt.Sprintf("cp -r %s %s", source, destination)
-
-// 	logger.Info("Copying snapshot db to temp location",
-// 		zap.String("command", copyCommand))
-// 	if stdout, err := ssh.RunCommandWithClient(sshClient, copyCommand); err != nil {
-// 		logger.Error(
-// 			fmt.Sprintf("failed to copy snapshot from %s to %s on remote: output", source, destination),
-// 			zap.String("stdout", stdout),
-// 			zap.Error(err),
-// 		)
-// 		return fmt.Errorf("failed to copy snapshot from %s to %s on remote: output: %s: %s", source, destination, stdout, err)
-// 	}
-
-// 	checkCommand := fmt.Sprintf("%s tools snapshot --db-path '%s'", RemoteVegaBinary, destination)
-// 	logger.Info("Checking if copied snapshot was copied correctly",
-// 		zap.String("command", checkCommand))
-// 	if stdout, err := ssh.RunCommandWithClient(sshClient, checkCommand); err != nil {
-// 		logger.Error(
-// 			"failed to check if snapshot was correctly copied on remote",
-// 			zap.String("stdout", stdout),
-// 			zap.Error(err),
-// 		)
-// 		return fmt.Errorf("failed to check if snapshot was correctly copied on remote: output: %s: %w", stdout, err)
-// 	}
-
-// 	return nil
-// }
-
-// func selectSnapshotHeight(vegaBinary, snapshotDbLocation string) (int, error) {
-// 	snapshotsResponse, err := vegacmd.ListCoreSnapshots(
-// 		vegaBinary,
-// 		vegacmd.CoreSnashotInput{SnapshotDbPath: snapshotDbLocation},
-// 	)
-// 	if err != nil {
-// 		return 0, fmt.Errorf("failed to list core snapshots: %w", err)
-// 	}
-
-// 	snapshotList := snapshotsResponse.Snapshots
-// 	sort.Slice(snapshotList, func(i, j int) bool {
-// 		return snapshotList[i].Height > snapshotList[j].Height
-// 	})
-// 	if len(snapshotList) < 1 {
-// 		return 0, fmt.Errorf(
-// 			"not enough snapshots: expected at least 1 snapshots, %d got",
-// 			len(snapshotList),
-// 		)
-// 	}
-// 	return snapshotList[0].Height, nil
-// }
-
-// func updateCoreConfig(coreHome string, startHeight int) error {
-// 	configPath := filepath.Join(coreHome, VegaCoreConfigPath)
-// 	coreConfigNode, err := dasel.NewFromFile(configPath, "toml")
-// 	if err != nil {
-// 		return fmt.Errorf("failed to read core config: %w", err)
-// 	}
-// 	if err := coreConfigNode.Put("Snapshot.StartHeight", startHeight); err != nil {
-// 		return fmt.Errorf("failed to set Snapshot.StartHeight in the vega node config: %w", err)
-// 	}
-// 	if err := coreConfigNode.WriteToFile(configPath, "toml", []storage.ReadWriteOption{}); err != nil {
-// 		return fmt.Errorf("failed to write the %s file: %w", configPath, err)
-// 	}
-
-// 	return nil
-// }
+	return nil
+}

--- a/cmd/snapshotcompatibility/root.go
+++ b/cmd/snapshotcompatibility/root.go
@@ -21,7 +21,7 @@ var SnapshotCompatibilityCmd = &cobra.Command{
 func init() {
 	snapshotCompatibilityArgs.RootArgs = &rootCmd.Args
 
-	// SnapshotCompatibilityCmd.AddCommand(loadSnapshotCmd)
+	SnapshotCompatibilityCmd.AddCommand(loadSnapshotCmd)
 	SnapshotCompatibilityCmd.AddCommand(downloadMainnetSnapshotCmd)
 	SnapshotCompatibilityCmd.AddCommand(downloadBinaryCmd)
 	SnapshotCompatibilityCmd.AddCommand(produceNewSnapshotCmd)

--- a/cmd/snapshotcompatibility/root.go
+++ b/cmd/snapshotcompatibility/root.go
@@ -21,7 +21,8 @@ var SnapshotCompatibilityCmd = &cobra.Command{
 func init() {
 	snapshotCompatibilityArgs.RootArgs = &rootCmd.Args
 
-	SnapshotCompatibilityCmd.AddCommand(loadSnapshotCmd)
+	// SnapshotCompatibilityCmd.AddCommand(loadSnapshotCmd)
+	SnapshotCompatibilityCmd.AddCommand(downloadMainnetSnapshotCmd)
 	SnapshotCompatibilityCmd.AddCommand(produceNewSnapshotCmd)
 	SnapshotCompatibilityCmd.AddCommand(collectSnapshotCmd)
 }

--- a/cmd/snapshotcompatibility/root.go
+++ b/cmd/snapshotcompatibility/root.go
@@ -23,6 +23,7 @@ func init() {
 
 	// SnapshotCompatibilityCmd.AddCommand(loadSnapshotCmd)
 	SnapshotCompatibilityCmd.AddCommand(downloadMainnetSnapshotCmd)
+	SnapshotCompatibilityCmd.AddCommand(downloadBinaryCmd)
 	SnapshotCompatibilityCmd.AddCommand(produceNewSnapshotCmd)
 	SnapshotCompatibilityCmd.AddCommand(collectSnapshotCmd)
 }

--- a/tools/os.go
+++ b/tools/os.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 )
 
@@ -22,4 +23,8 @@ func WhoAmI() (string, error) {
 	}
 
 	return strings.Trim(string(out), " \t\n"), nil
+}
+
+func FormatAssetName(name string, extension string) string {
+	return fmt.Sprintf("%s-%s-%s.%s", name, runtime.GOOS, runtime.GOARCH, extension)
 }


### PR DESCRIPTION
# Changes

- Added function to download the mainnet binary
- Split the load-snapshot function to two separated commands: 
    - Download mainnet snapshot
    - Load snapshot into network

The new approach will be:

```

vegacapsule network destroy \
  --home-path /home/daniel/www/networkdata-mainnet/

go run main.go snapshot-compatibility download-binary \
  --destination ~/go/bin/vega-mainnet \
  --core-rest-endpoint api2.vega.community \
  --repository vegaprotocol/vega

vegacapsule network generate \
  --force \
  --config-path ./vegacapsule/capsule_config_mainnet_snapshot_compatibility_mainnet.hcl \
  --home-path /home/daniel/www/networkdata-mainnet/

go run main.go snapshot-compatibility download-mainnet-snapshot \
  --snapshot-remote-location "/home/vega/vega_home/state/node/snapshots" \
  --snapshot-server "api2.vega.community" \
  --snapshot-server-key-file "/home/daniel/.ssh/id_rsa" \
  --snapshot-server-user "daniel" \
  --local-temporary-destination /tmp/mainnet-snapshot


go run main.go snapshot-compatibility load-snapshot \
  --snapshot-location /tmp/mainnet-snapshot \
  --vegacapsule-binary "vegacapsule" \
  --vega-binary "vega-mainnet" \
  --vegacapsule-home "/home/daniel/www/networkdata-mainnet/"

vegacapsule network start \
  --home-path /home/daniel/www/networkdata-mainnet/ \
  --do-not-stop-on-failure
```



# Related PRs

- https://github.com/vegaprotocol/jenkins-shared-library/pull/690
- https://github.com/vegaprotocol/devopstools/pull/82
- https://github.com/vegaprotocol/system-tests/pull/2839