### PR TITLE
feat: filter only alive markets when filtering for create command or provide lp

### DIFF
--- a/cmd/market/providelp.go
+++ b/cmd/market/providelp.go
@@ -66,7 +66,7 @@ func RunProvideLP(args ProvideLPArgs) error {
 
 	failed := false
 	for _, marketName := range []string{"AAPL", "AAVEDAI", "BTCUSD", "ETHBTC", "TSLA", "UNIDAI", "ETHDAI"} {
-		market := governance.GetMarket(markets, proposerVegawallet.PublicKey, fmt.Sprintf("auto:%s", strings.ToLower(marketName)))
+		market := governance.GetMarket(markets, proposerVegawallet.PublicKey, fmt.Sprintf("auto:%s", strings.ToLower(marketName)), governance.LiveMarketStates)
 		if market == nil {
 			logger.Info("market does not exists", zap.String("market", marketName))
 		} else {


### PR DESCRIPTION
# The issue

We call the following function:

```go
res, err := n.ListMarkets(&dataapipb.ListMarketsRequest{})
```

The above function returns all of the markets - including terminated, closed, etc... When We terminate the market, they are still returned by the above function. When We want to create a market, We filter it by metadata tags - We cannot create it because our script thinks it already exists (even if it is terminated). 

We have an issue with providing the LP for dead markets. for the same reasons.

# Changes

Added filters for the market.