### PR TITLE
feat: vote assets assets command + mainnet markets

### DIFF
--- a/cmd/market/config.go
+++ b/cmd/market/config.go
@@ -26,7 +26,8 @@ type networkAssetsIDs struct {
 	UNIDAI  string
 	ETHDAI  string
 
-	SettlementAsset_USDC string
+	SettlementAsset_USDC  string
+	MainnetLikeAsset_USDT string
 }
 
 var settlementAssetIDs map[string]networkAssetsIDs = map[string]networkAssetsIDs{
@@ -47,7 +48,8 @@ var settlementAssetIDs map[string]networkAssetsIDs = map[string]networkAssetsIDs
 		UNIDAI:  "b340c130096819428a62e5df407fd6abe66e444b89ad64f670beb98621c9c663", // "tDAI"
 		ETHDAI:  "b340c130096819428a62e5df407fd6abe66e444b89ad64f670beb98621c9c663", // "tDAI"
 
-		SettlementAsset_USDC: "c9fe6fc24fce121b2cc72680543a886055abb560043fda394ba5376203b7527d", // "tUSDC"
+		SettlementAsset_USDC:  "c9fe6fc24fce121b2cc72680543a886055abb560043fda394ba5376203b7527d", // "tUSDC"
+		MainnetLikeAsset_USDT: "",
 	},
 	types.NetworkStagnet1: {
 		AAPL:    "c9fe6fc24fce121b2cc72680543a886055abb560043fda394ba5376203b7527d", // "tUSDC"
@@ -58,7 +60,8 @@ var settlementAssetIDs map[string]networkAssetsIDs = map[string]networkAssetsIDs
 		UNIDAI:  "b340c130096819428a62e5df407fd6abe66e444b89ad64f670beb98621c9c663", // "tDAI"
 		ETHDAI:  "b340c130096819428a62e5df407fd6abe66e444b89ad64f670beb98621c9c663", // "tDAI"
 
-		SettlementAsset_USDC: "c9fe6fc24fce121b2cc72680543a886055abb560043fda394ba5376203b7527d", // "tUSDC"
+		SettlementAsset_USDC:  "c9fe6fc24fce121b2cc72680543a886055abb560043fda394ba5376203b7527d", // "tUSDC"
+		MainnetLikeAsset_USDT: "",
 	},
 	types.NetworkStagnet3: {
 		AAPL:    "ede4076aef07fd79502d14326c54ab3911558371baaf697a19d077f4f89de399", // "tUSDC"
@@ -68,6 +71,9 @@ var settlementAssetIDs map[string]networkAssetsIDs = map[string]networkAssetsIDs
 		TSLA:    "4e4e80abff30cab933b8c4ac6befc618372eb76b2cbddc337eff0b4a3a4d25b8", // "tEURO"
 		UNIDAI:  "16ae5dbb1fd7aa2ddef725703bfe66b3647a4da7b844bfdd04e985756f53d9d6", // "tDAI"
 		ETHDAI:  "16ae5dbb1fd7aa2ddef725703bfe66b3647a4da7b844bfdd04e985756f53d9d6", // "tDAI"
+
+		SettlementAsset_USDC:  "",
+		MainnetLikeAsset_USDT: "",
 	},
 	types.NetworkFairground: {
 		AAPL:    "c9fe6fc24fce121b2cc72680543a886055abb560043fda394ba5376203b7527d", // "tUSDC"
@@ -78,6 +84,7 @@ var settlementAssetIDs map[string]networkAssetsIDs = map[string]networkAssetsIDs
 		UNIDAI:  "b340c130096819428a62e5df407fd6abe66e444b89ad64f670beb98621c9c663", // "tDAI"
 		ETHDAI:  "b340c130096819428a62e5df407fd6abe66e444b89ad64f670beb98621c9c663", // "tDAI"
 
-		SettlementAsset_USDC: "c9fe6fc24fce121b2cc72680543a886055abb560043fda394ba5376203b7527d", // "tUSDC"
+		SettlementAsset_USDC:  "c9fe6fc24fce121b2cc72680543a886055abb560043fda394ba5376203b7527d", // "tUSDC"
+		MainnetLikeAsset_USDT: "8ba0b10971f0c4747746cd01ff05a53ae75ca91eba1d4d050b527910c983e27e", // Probably should be fetched dynamicly
 	},
 }

--- a/cmd/market/terminate.go
+++ b/cmd/market/terminate.go
@@ -80,6 +80,10 @@ func findMarkets(dataNodeClient vegaapi.DataNodeClient, allMarkets bool, managed
 	}
 
 	for _, market := range markets {
+		if !slices.Contains(governance.LiveMarketStates, market.State) {
+			continue
+		}
+
 		if allMarkets || slices.Contains(marketIds, market.Id) || isManaged(market) {
 			result = append(result, marketDetails{
 				id:   market.Id,

--- a/cmd/propose/assets.go
+++ b/cmd/propose/assets.go
@@ -102,6 +102,10 @@ func getAssets(env string) []assetsgov.AssetProposalDetails {
 	return result
 }
 
+func isAssetSame(deployed *vega.AssetDetails, proposed *assetsgov.AssetProposalDetails) bool {
+	return false
+}
+
 func ProposeAssetRun(args *ProposeAssetArgs) error {
 	logger := args.Logger
 	network, err := args.ConnectToVegaNetwork(args.VegaNetworkName)

--- a/cmd/propose/assets.go
+++ b/cmd/propose/assets.go
@@ -11,6 +11,7 @@ import (
 	"code.vegaprotocol.io/vega/protos/vega"
 	commandspb "code.vegaprotocol.io/vega/protos/vega/commands/v1"
 	walletpb "code.vegaprotocol.io/vega/protos/vega/wallet/v1"
+	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 	"github.com/vegaprotocol/devopstools/governance"
 	assetsgov "github.com/vegaprotocol/devopstools/governance/assets"
@@ -27,7 +28,7 @@ var proposeAssetArgs ProposeAssetArgs
 
 // provideLPCmd represents the provideLP command
 var proposeAssetCmd = &cobra.Command{
-	Use:   "asset",
+	Use:   "assets",
 	Short: "Propose asset",
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := ProposeAssetRun(&proposeAssetArgs); err != nil {
@@ -115,12 +116,15 @@ func ProposeAssetRun(args *ProposeAssetArgs) error {
 	}
 
 	assetsByERC20 := map[string]*vega.AssetDetails{}
-	for _, asset := networkAssets {
+	for _, asset := range networkAssets {
 		erc20 := asset.GetErc20()
 		if erc20 == nil {
 			continue
 		}
+		assetsByERC20[erc20.ContractAddress] = asset
 	}
+
+	var errs *multierror.Error
 
 	for _, assetDetails := range getAssets(network.Network) {
 		logger.Info("Proposing ERC20 asset",
@@ -133,82 +137,145 @@ func ProposeAssetRun(args *ProposeAssetArgs) error {
 			zap.String("lifetime-limit", assetDetails.ERC20LifetimeLimit),
 		)
 
+		if _, assetAlreadyCreated := assetsByERC20[assetDetails.ERC20Address]; assetAlreadyCreated {
+			logger.Info("Asset with given erc20 address already created",
+				zap.String("name", assetDetails.Name),
+				zap.String("symbol", assetDetails.Symbol),
+				zap.String("erc20-address", assetDetails.ERC20Address),
+			)
+
+			continue
+		}
+
 		minClose, err := time.ParseDuration(network.NetworkParams.Params[netparams.GovernanceProposalMarketMinClose])
 		if err != nil {
-			return fmt.Errorf("failed to parse duration for %s: %w", netparams.GovernanceProposalMarketMinClose, err)
+			cError := fmt.Errorf("failed to parse duration for %s: %w", netparams.GovernanceProposalMarketMinClose, err)
+			logger.Error(
+				"failed to propose asset",
+				zap.Error(cError),
+				zap.String("name", assetDetails.Name),
+			)
+			errs = multierror.Append(cError)
+			continue
 		}
 		minEnact, err := time.ParseDuration(network.NetworkParams.Params[netparams.GovernanceProposalMarketMinEnact])
 		if err != nil {
-			return fmt.Errorf("failed to parse duration for %s: %w", netparams.GovernanceProposalMarketMinEnact, err)
+			cError := fmt.Errorf("failed to parse duration for %s: %w", netparams.GovernanceProposalMarketMinEnact, err)
+			logger.Error(
+				"failed to propose asset",
+				zap.Error(cError),
+				zap.String("name", assetDetails.Name),
+			)
+			errs = multierror.Append(cError)
+			continue
 		}
 
 		closingTime := time.Now().Add(time.Second * 20).Add(minClose)
 		enactmentTime := time.Now().Add(time.Second * 30).Add(minClose).Add(minEnact)
 
 		proposal := assetsgov.NewAssetProposal(closingTime, enactmentTime, assetDetails)
-	}
 
-	args.Logger.Info("Proposing asset")
-
-	args.Logger.Info("Proposing asset: Sending proposal")
-	walletTxReq := walletpb.SubmitTransactionRequest{
-		PubKey: network.VegaTokenWhale.PublicKey,
-		Command: &walletpb.SubmitTransactionRequest_ProposalSubmission{
-			ProposalSubmission: proposal,
-		},
-	}
-	if err := governance.SubmitTx("propose asset", network.DataNodeClient, network.VegaTokenWhale, args.Logger, &walletTxReq); err != nil {
-		return err
-	}
-
-	args.Logger.Info("Proposing asset: Waiting for proposal to be picked up on the network")
-	proposalId, err := tools.RetryReturn(6, 10*time.Second, func() (string, error) {
-		reference := proposal.Reference
-
-		res, err := network.DataNodeClient.ListGovernanceData(&v2.ListGovernanceDataRequest{
-			ProposalReference: &reference,
-		})
-		if err != nil {
-			return "", fmt.Errorf("failed to list governance data for reference %s: %w", proposal.Reference, err)
-		}
-		var proposalId string
-		for _, edge := range res.Connection.Edges {
-			if edge.Node.Proposal.Reference == reference {
-				args.Logger.Info("Found proposal", zap.String("reference", reference),
-					zap.String("status", edge.Node.Proposal.State.String()),
-					zap.Any("proposal", edge.Node.Proposal))
-				proposalId = edge.Node.Proposal.Id
-				break
-			}
-		}
-
-		if len(proposalId) < 1 {
-			return "", fmt.Errorf("got empty proposal id for the %s reference", reference)
-		}
-
-		return proposalId, nil
-	})
-
-	if err != nil {
-		return fmt.Errorf("failed to find proposal for new asset:%w", err)
-	}
-	args.Logger.Info("Proposing asset: Proposal found", zap.String("proposal-id", proposalId))
-
-	args.Logger.Info("Proposing asset: Voting on proposal", zap.String("proposal-id", proposalId))
-	voteWalletTxReq := walletpb.SubmitTransactionRequest{
-		PubKey: network.VegaTokenWhale.PublicKey,
-		Command: &walletpb.SubmitTransactionRequest_VoteSubmission{
-			VoteSubmission: &commandspb.VoteSubmission{
-				ProposalId: proposalId,
-				Value:      vega.Vote_VALUE_YES,
+		args.Logger.Info("Proposing asset: Sending proposal", zap.String("name", assetDetails.Name))
+		walletTxReq := walletpb.SubmitTransactionRequest{
+			PubKey: network.VegaTokenWhale.PublicKey,
+			Command: &walletpb.SubmitTransactionRequest_ProposalSubmission{
+				ProposalSubmission: proposal,
 			},
-		},
-	}
-	if err := governance.SubmitTx("vote on asset proposal", network.DataNodeClient, network.VegaTokenWhale, args.Logger, &voteWalletTxReq); err != nil {
-		return err
+		}
+
+		if err := governance.SubmitTx("propose asset", network.DataNodeClient, network.VegaTokenWhale, args.Logger, &walletTxReq); err != nil {
+			cError := fmt.Errorf("failed to submit propose asset transaction: %w", err)
+			logger.Error(
+				"failed to propose asset",
+				zap.Error(cError),
+				zap.String("name", assetDetails.Name),
+			)
+			errs = multierror.Append(cError)
+			continue
+		}
+
+		args.Logger.Info(
+			"Proposing asset: Waiting for proposal to be picked up on the network",
+			zap.String("name", assetDetails.Name),
+			zap.String("ref", proposal.Reference),
+		)
+		proposalId, err := tools.RetryReturn(6, 10*time.Second, func() (string, error) {
+			reference := proposal.Reference
+
+			res, err := network.DataNodeClient.ListGovernanceData(&v2.ListGovernanceDataRequest{
+				ProposalReference: &reference,
+			})
+			if err != nil {
+				return "", fmt.Errorf("failed to list governance data for reference %s: %w", proposal.Reference, err)
+			}
+			var proposalId string
+			for _, edge := range res.Connection.Edges {
+				if edge.Node.Proposal.Reference == reference {
+					args.Logger.Info("Found proposal", zap.String("reference", reference),
+						zap.String("status", edge.Node.Proposal.State.String()),
+						zap.Any("proposal", edge.Node.Proposal),
+						zap.String("name", assetDetails.Name),
+					)
+					proposalId = edge.Node.Proposal.Id
+					break
+				}
+			}
+
+			if len(proposalId) < 1 {
+				return "", fmt.Errorf("got empty proposal id for the %s reference", reference)
+			}
+
+			return proposalId, nil
+		})
+
+		if err != nil {
+			cError := fmt.Errorf("failed to find proposal for new asset:%w", err)
+
+			logger.Error(
+				"failed to propose asset",
+				zap.Error(cError),
+				zap.String("name", assetDetails.Name),
+			)
+			errs = multierror.Append(cError)
+			continue
+		}
+
+		args.Logger.Info("Proposing asset: Proposal found",
+			zap.String("proposal-id", proposalId),
+			zap.String("name", assetDetails.Name),
+		)
+
+		args.Logger.Info("Proposing asset: Voting on proposal",
+			zap.String("proposal-id", proposalId),
+			zap.String("name", assetDetails.Name),
+		)
+
+		voteWalletTxReq := walletpb.SubmitTransactionRequest{
+			PubKey: network.VegaTokenWhale.PublicKey,
+			Command: &walletpb.SubmitTransactionRequest_VoteSubmission{
+				VoteSubmission: &commandspb.VoteSubmission{
+					ProposalId: proposalId,
+					Value:      vega.Vote_VALUE_YES,
+				},
+			},
+		}
+		if err := governance.SubmitTx("vote on asset proposal", network.DataNodeClient, network.VegaTokenWhale, args.Logger, &voteWalletTxReq); err != nil {
+			cError := fmt.Errorf("failet to vote on the asset proposal: %w")
+
+			logger.Error(
+				"failed to propose asset",
+				zap.Error(cError),
+				zap.String("name", assetDetails.Name),
+			)
+			errs = multierror.Append(cError)
+			continue
+		}
+
+		args.Logger.Info("Proposing asset: Voted on proposal",
+			zap.String("proposal-id", proposalId),
+			zap.String("name", assetDetails.Name),
+		)
 	}
 
-	args.Logger.Info("Proposing asset: Voted on proposal", zap.String("proposal-id", proposalId))
-
-	return nil
+	return errs.ErrorOrNil()
 }

--- a/cmd/propose/assets.go
+++ b/cmd/propose/assets.go
@@ -1,0 +1,214 @@
+package propose
+
+import (
+	"fmt"
+	"math/big"
+	"os"
+	"time"
+
+	"code.vegaprotocol.io/vega/core/netparams"
+	v2 "code.vegaprotocol.io/vega/protos/data-node/api/v2"
+	"code.vegaprotocol.io/vega/protos/vega"
+	commandspb "code.vegaprotocol.io/vega/protos/vega/commands/v1"
+	walletpb "code.vegaprotocol.io/vega/protos/vega/wallet/v1"
+	"github.com/spf13/cobra"
+	"github.com/vegaprotocol/devopstools/governance"
+	assetsgov "github.com/vegaprotocol/devopstools/governance/assets"
+	"github.com/vegaprotocol/devopstools/tools"
+	"github.com/vegaprotocol/devopstools/types"
+	"go.uber.org/zap"
+)
+
+type ProposeAssetArgs struct {
+	*ProposeArgs
+}
+
+var proposeAssetArgs ProposeAssetArgs
+
+// provideLPCmd represents the provideLP command
+var proposeAssetCmd = &cobra.Command{
+	Use:   "asset",
+	Short: "Propose asset",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := ProposeAssetRun(&proposeAssetArgs); err != nil {
+			proposeAssetArgs.Logger.Error("Error", zap.Error(err))
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	proposeAssetArgs.ProposeArgs = &proposeArgs
+	ProposeCmd.AddCommand(proposeAssetCmd)
+}
+
+func getAssets(env string) []assetsgov.AssetProposalDetails {
+	result := []assetsgov.AssetProposalDetails{}
+
+	if env != types.NetworkFairground {
+		return result
+	}
+
+	// FairgroundAssets
+	result = []assetsgov.AssetProposalDetails{
+		{
+			Name:                     "Wrapped Ether",
+			Symbol:                   "WETH",
+			Decimals:                 18,
+			Quantum:                  big.NewInt(500000000000000),
+			ERC20Address:             "0xC0DF5eB3e58f21026E6F997Dd9C3e1Fa07d22428",
+			ERC20LifetimeLimit:       "50000000000000000000",
+			ERC20WithdrawalThreshold: "1",
+		},
+		{
+			Name:                     "Dai Stablecoin",
+			Symbol:                   "DAI",
+			Decimals:                 18,
+			Quantum:                  big.NewInt(1000000000000000000),
+			ERC20Address:             "0x12ba0B32016099d19E685113123ba7018d702EA2",
+			ERC20LifetimeLimit:       "10000000000000000000000",
+			ERC20WithdrawalThreshold: "1",
+		},
+		{
+			Name:                     "Wrapped Ether",
+			Symbol:                   "WETH",
+			Decimals:                 18,
+			Quantum:                  big.NewInt(500000000000000),
+			ERC20Address:             "0xC0DF5eB3e58f21026E6F997Dd9C3e1Fa07d22428",
+			ERC20LifetimeLimit:       "50000000000000000000",
+			ERC20WithdrawalThreshold: "1",
+		},
+		{
+			Name:                     "Tether USD",
+			Symbol:                   "USDT",
+			Decimals:                 6,
+			Quantum:                  big.NewInt(1000000),
+			ERC20Address:             "0xdb10bf403771e44d0456f6c51ee655bb67ab05d9",
+			ERC20LifetimeLimit:       "100000000000",
+			ERC20WithdrawalThreshold: "1",
+		},
+		{
+			Name:                     "USDC",
+			Symbol:                   "USDC",
+			Decimals:                 6,
+			Quantum:                  big.NewInt(1000000),
+			ERC20Address:             "0x3af2115f79614e66d98560ded281693909499192",
+			ERC20LifetimeLimit:       "100000000000",
+			ERC20WithdrawalThreshold: "1",
+		},
+	}
+
+	return result
+}
+
+func ProposeAssetRun(args *ProposeAssetArgs) error {
+	logger := args.Logger
+	network, err := args.ConnectToVegaNetwork(args.VegaNetworkName)
+	if err != nil {
+		return err
+	}
+	defer network.Disconnect()
+
+	networkAssets, err := network.DataNodeClient.GetAssets()
+	if err != nil {
+		return fmt.Errorf("failed to get assets already created on the network: %w", err)
+	}
+
+	assetsByERC20 := map[string]*vega.AssetDetails{}
+	for _, asset := networkAssets {
+		erc20 := asset.GetErc20()
+		if erc20 == nil {
+			continue
+		}
+	}
+
+	for _, assetDetails := range getAssets(network.Network) {
+		logger.Info("Proposing ERC20 asset",
+			zap.String("name", assetDetails.Name),
+			zap.String("symbol", assetDetails.Symbol),
+			zap.Uint64("decimals", assetDetails.Decimals),
+			zap.String("quantum", assetDetails.Quantum.String()),
+			zap.String("erc20-address", assetDetails.ERC20Address),
+			zap.String("withdrawal-threshold", assetDetails.ERC20WithdrawalThreshold),
+			zap.String("lifetime-limit", assetDetails.ERC20LifetimeLimit),
+		)
+
+		minClose, err := time.ParseDuration(network.NetworkParams.Params[netparams.GovernanceProposalMarketMinClose])
+		if err != nil {
+			return fmt.Errorf("failed to parse duration for %s: %w", netparams.GovernanceProposalMarketMinClose, err)
+		}
+		minEnact, err := time.ParseDuration(network.NetworkParams.Params[netparams.GovernanceProposalMarketMinEnact])
+		if err != nil {
+			return fmt.Errorf("failed to parse duration for %s: %w", netparams.GovernanceProposalMarketMinEnact, err)
+		}
+
+		closingTime := time.Now().Add(time.Second * 20).Add(minClose)
+		enactmentTime := time.Now().Add(time.Second * 30).Add(minClose).Add(minEnact)
+
+		proposal := assetsgov.NewAssetProposal(closingTime, enactmentTime, assetDetails)
+	}
+
+	args.Logger.Info("Proposing asset")
+
+	args.Logger.Info("Proposing asset: Sending proposal")
+	walletTxReq := walletpb.SubmitTransactionRequest{
+		PubKey: network.VegaTokenWhale.PublicKey,
+		Command: &walletpb.SubmitTransactionRequest_ProposalSubmission{
+			ProposalSubmission: proposal,
+		},
+	}
+	if err := governance.SubmitTx("propose asset", network.DataNodeClient, network.VegaTokenWhale, args.Logger, &walletTxReq); err != nil {
+		return err
+	}
+
+	args.Logger.Info("Proposing asset: Waiting for proposal to be picked up on the network")
+	proposalId, err := tools.RetryReturn(6, 10*time.Second, func() (string, error) {
+		reference := proposal.Reference
+
+		res, err := network.DataNodeClient.ListGovernanceData(&v2.ListGovernanceDataRequest{
+			ProposalReference: &reference,
+		})
+		if err != nil {
+			return "", fmt.Errorf("failed to list governance data for reference %s: %w", proposal.Reference, err)
+		}
+		var proposalId string
+		for _, edge := range res.Connection.Edges {
+			if edge.Node.Proposal.Reference == reference {
+				args.Logger.Info("Found proposal", zap.String("reference", reference),
+					zap.String("status", edge.Node.Proposal.State.String()),
+					zap.Any("proposal", edge.Node.Proposal))
+				proposalId = edge.Node.Proposal.Id
+				break
+			}
+		}
+
+		if len(proposalId) < 1 {
+			return "", fmt.Errorf("got empty proposal id for the %s reference", reference)
+		}
+
+		return proposalId, nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to find proposal for new asset:%w", err)
+	}
+	args.Logger.Info("Proposing asset: Proposal found", zap.String("proposal-id", proposalId))
+
+	args.Logger.Info("Proposing asset: Voting on proposal", zap.String("proposal-id", proposalId))
+	voteWalletTxReq := walletpb.SubmitTransactionRequest{
+		PubKey: network.VegaTokenWhale.PublicKey,
+		Command: &walletpb.SubmitTransactionRequest_VoteSubmission{
+			VoteSubmission: &commandspb.VoteSubmission{
+				ProposalId: proposalId,
+				Value:      vega.Vote_VALUE_YES,
+			},
+		},
+	}
+	if err := governance.SubmitTx("vote on asset proposal", network.DataNodeClient, network.VegaTokenWhale, args.Logger, &voteWalletTxReq); err != nil {
+		return err
+	}
+
+	args.Logger.Info("Proposing asset: Voted on proposal", zap.String("proposal-id", proposalId))
+
+	return nil
+}

--- a/cmd/propose/assets.go
+++ b/cmd/propose/assets.go
@@ -50,7 +50,7 @@ func getAssets(env string) []assetsgov.AssetProposalDetails {
 		return result
 	}
 
-	// FairgroundAssets
+	// Fairground Assets
 	result = []assetsgov.AssetProposalDetails{
 		{
 			Name:                     "Wrapped Ether",

--- a/governance/assets/proposals.go
+++ b/governance/assets/proposals.go
@@ -62,3 +62,34 @@ Proposal to add USD Rewards ($%s) as a settlement asset as discussed for incenti
 		},
 	}
 }
+
+func UpdateAssetProposal(closingTime, enactmentTime time.Time, assetId string, details AssetProposalDetails) *commandspb.ProposalSubmission {
+	reference := tools.RandAlphaNumericString(40)
+
+	return &commandspb.ProposalSubmission{
+		Reference: reference,
+		Rationale: &vega.ProposalRationale{
+			Title:       fmt.Sprintf("Create Asset - %s ($%s)", details.Name, details.Symbol),
+			Description: fmt.Sprintf(`Update the %s($%s) asset`, details.Name, details.Symbol),
+		},
+		Terms: &vega.ProposalTerms{
+			ClosingTimestamp:    closingTime.Unix(),
+			EnactmentTimestamp:  enactmentTime.Unix(),
+			ValidationTimestamp: closingTime.Unix() - 1,
+			Change: &vega.ProposalTerms_UpdateAsset{
+				UpdateAsset: &vega.UpdateAsset{
+					AssetId: assetId,
+					Changes: &vega.AssetDetailsUpdate{
+						Quantum: details.Quantum.String(),
+						Source: &vega.AssetDetailsUpdate_Erc20{
+							Erc20: &vega.ERC20Update{
+								WithdrawThreshold: details.ERC20WithdrawalThreshold,
+								LifetimeLimit:     details.ERC20LifetimeLimit,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/governance/assets/proposals.go
+++ b/governance/assets/proposals.go
@@ -1,0 +1,64 @@
+package assets
+
+import (
+	"fmt"
+	"math/big"
+	"time"
+
+	"code.vegaprotocol.io/vega/protos/vega"
+	commandspb "code.vegaprotocol.io/vega/protos/vega/commands/v1"
+	"github.com/vegaprotocol/devopstools/tools"
+)
+
+type AssetProposalDetails struct {
+	Name     string
+	Symbol   string
+	Decimals uint64
+	Quantum  *big.Int
+
+	ERC20Address             string
+	ERC20WithdrawalThreshold string
+	ERC20LifetimeLimit       string
+}
+
+func NewAssetProposal(closingTime, enactmentTime time.Time, details AssetProposalDetails) *commandspb.ProposalSubmission {
+	reference := tools.RandAlphaNumericString(40)
+
+	return &commandspb.ProposalSubmission{
+		Reference: reference,
+		Rationale: &vega.ProposalRationale{
+			Title: fmt.Sprintf("Create Asset - %s ($%s)", details.Name, details.Symbol),
+			Description: fmt.Sprintf(`## Summary
+
+Proposal to add USD Rewards ($%s) as a settlement asset as discussed for incentive iceberg orders
+
+## Rationale
+
+- USD Rewards ($%s) will have one market trading on it BTC
+- Name: %s
+- ERC20 Token(%s)`, details.Symbol, details.Symbol, details.Name, details.ERC20Address),
+		},
+		Terms: &vega.ProposalTerms{
+			ClosingTimestamp:    closingTime.Unix(),
+			EnactmentTimestamp:  enactmentTime.Unix(),
+			ValidationTimestamp: closingTime.Unix() - 1,
+			Change: &vega.ProposalTerms_NewAsset{
+				NewAsset: &vega.NewAsset{
+					Changes: &vega.AssetDetails{
+						Name:     details.Name,
+						Symbol:   details.Symbol,
+						Decimals: details.Decimals,
+						Quantum:  details.Quantum.String(),
+						Source: &vega.AssetDetails_Erc20{
+							Erc20: &vega.ERC20{
+								ContractAddress:   details.ERC20Address,
+								WithdrawThreshold: details.ERC20WithdrawalThreshold,
+								LifetimeLimit:     details.ERC20LifetimeLimit,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/governance/market/mainnet_btc_usdt.go
+++ b/governance/market/mainnet_btc_usdt.go
@@ -15,7 +15,7 @@ const MainnetBTCUSDTMetadataID = "auto:mainnet_btc_usdt"
 var (
 	MainnetBTCUSDTOracleDecimalPlaces   = uint64(6)
 	MainnetBTCUSDTMarketSettlementHours = 24 * 31
-	MainnetBTCUSDTPositionDecimalPlaces = int64(3)
+	MainnetBTCUSDTPositionDecimalPlaces = int64(4)
 	MainnetBTCUSDTDecimalPlaces         = uint64(1)
 )
 
@@ -26,7 +26,7 @@ func NewMainnetBTCUSDT(
 	closingTime time.Time,
 	enactmentTime time.Time,
 	extraMetadata []string,
-) (*commandspb.ProposalSubmission, error) {
+) *commandspb.ProposalSubmission {
 	reference := tools.RandAlphaNumericString(40)
 
 	nowTime := time.Now()
@@ -180,14 +180,19 @@ This proposal requests to list BTC/USDT-231231 as a market with USDT as a settle
 								},
 							},
 						},
-						PositionDecimalPlaces:   MainnetBTCUSDTPositionDecimalPlaces,
-						LpPriceRange:            &[]string{"0.05"}[0],
-						LiquiditySlaParameters:  nil,
+						PositionDecimalPlaces: MainnetBTCUSDTPositionDecimalPlaces,
+						LpPriceRange:          &[]string{"0.05"}[0],
+						LiquiditySlaParameters: &vega.LiquiditySLAParameters{
+							PerformanceHysteresisEpochs: 1,
+							PriceRange:                  "0.05",
+							SlaCompetitionFactor:        "0.90",
+							CommitmentMinTimeFraction:   "0.95",
+						},
 						LinearSlippageFactor:    "0.001",
 						QuadraticSlippageFactor: "0",
 					},
 				},
 			},
 		},
-	}, nil
+	}
 }

--- a/governance/market/mainnet_btc_usdt.go
+++ b/governance/market/mainnet_btc_usdt.go
@@ -1,0 +1,193 @@
+package market
+
+import (
+	"fmt"
+	"time"
+
+	"code.vegaprotocol.io/vega/protos/vega"
+	commandspb "code.vegaprotocol.io/vega/protos/vega/commands/v1"
+	datav1 "code.vegaprotocol.io/vega/protos/vega/data/v1"
+	"github.com/vegaprotocol/devopstools/tools"
+)
+
+const MainnetBTCUSDTMetadataID = "auto:mainnet_btc_usdt"
+
+var (
+	MainnetBTCUSDTOracleDecimalPlaces   = uint64(6)
+	MainnetBTCUSDTMarketSettlementHours = 24 * 31
+	MainnetBTCUSDTPositionDecimalPlaces = int64(3)
+	MainnetBTCUSDTDecimalPlaces         = uint64(1)
+)
+
+// settlementVegaAssetId ideally with 6 decimal places
+func NewMainnetBTCUSDT(
+	settlementVegaAssetId string,
+	oraclePubKey string,
+	closingTime time.Time,
+	enactmentTime time.Time,
+	extraMetadata []string,
+) (*commandspb.ProposalSubmission, error) {
+	reference := tools.RandAlphaNumericString(40)
+
+	nowTime := time.Now()
+	settlementTime := nowTime.Add(time.Hour * (time.Duration(MainnetBTCUSDTMarketSettlementHours)))
+
+	return &commandspb.ProposalSubmission{
+		Reference: reference,
+		Rationale: &vega.ProposalRationale{
+			Title: "BTC/USDT Mainnet Copy",
+			Description: `# Summary
+
+This proposal requests to list BTC/USDT-231231 as a market with USDT as a settlement asset on the Vega Network as discussed in: https://community.vega.xyz/.
+			
+# Rationale
+			
+	* BTC is the largest Crypto asset with the highest volume and Marketcap.
+	* Given the price, 1 decimal places will be used for price due to the number of valid digits in asset price.
+	* Position decimal places will be set to 4 considering the value per contract
+	* USDT is chosen as settlement asset due to its stability.`,
+		},
+
+		Terms: &vega.ProposalTerms{
+			ClosingTimestamp:   closingTime.Unix(),
+			EnactmentTimestamp: enactmentTime.Unix(),
+			Change: &vega.ProposalTerms_NewMarket{
+				NewMarket: &vega.NewMarket{
+					Changes: &vega.NewMarketConfiguration{
+						Instrument: &vega.InstrumentConfiguration{
+							Name: "BTC/USDT Mainnet Copy",
+							Code: "BTC/USDT-MAINNET",
+							Product: &vega.InstrumentConfiguration_Future{
+								Future: &vega.FutureProduct{
+									SettlementAsset: settlementVegaAssetId,
+									QuoteName:       "USDT",
+									DataSourceSpecForSettlementData: &vega.DataSourceDefinition{
+										SourceType: &vega.DataSourceDefinition_External{
+											External: &vega.DataSourceDefinitionExternal{
+												SourceType: &vega.DataSourceDefinitionExternal_Oracle{
+													Oracle: &vega.DataSourceSpecConfiguration{
+														Signers: []*datav1.Signer{
+															{
+																Signer: &datav1.Signer_EthAddress{
+																	EthAddress: &datav1.ETHAddress{
+																		Address: oraclePubKey,
+																	},
+																},
+															},
+														},
+														Filters: []*datav1.Filter{
+															{
+																Key: &datav1.PropertyKey{
+																	Name:                "prices.BTC.value",
+																	Type:                datav1.PropertyKey_TYPE_INTEGER,
+																	NumberDecimalPlaces: &MainnetBTCUSDTOracleDecimalPlaces,
+																},
+																Conditions: []*datav1.Condition{
+																	{
+																		Operator: datav1.Condition_OPERATOR_GREATER_THAN,
+																		Value:    "0",
+																	},
+																},
+															},
+															{
+																Key: &datav1.PropertyKey{
+																	Name: "prices.BTC.timestamp",
+																	Type: datav1.PropertyKey_TYPE_TIMESTAMP,
+																},
+																Conditions: []*datav1.Condition{
+																	{
+																		Operator: datav1.Condition_OPERATOR_GREATER_THAN_OR_EQUAL,
+																		Value:    fmt.Sprintf("%d", settlementTime.Unix()),
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									DataSourceSpecForTradingTermination: &vega.DataSourceDefinition{
+										SourceType: &vega.DataSourceDefinition_Internal{
+											Internal: &vega.DataSourceDefinitionInternal{
+												SourceType: &vega.DataSourceDefinitionInternal_Time{
+													Time: &vega.DataSourceSpecConfigurationTime{
+														Conditions: []*datav1.Condition{
+															{
+																Operator: datav1.Condition_OPERATOR_GREATER_THAN_OR_EQUAL,
+																Value:    fmt.Sprintf("%d", settlementTime.Unix()),
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									DataSourceSpecBinding: &vega.DataSourceSpecToFutureBinding{
+										SettlementDataProperty:     "prices.BTC.value",
+										TradingTerminationProperty: "vegaprotocol.builtin.timestamp",
+									},
+								},
+							},
+						},
+						DecimalPlaces: MainnetBTCUSDTDecimalPlaces,
+						Metadata: append([]string{
+							"base:BTC",
+							"quote:USDT",
+							"class:fx/crypto",
+							"quarterly",
+							"sector:defi",
+							fmt.Sprintf("enactment:%s", enactmentTime.Format(time.RFC3339)),
+							fmt.Sprintf("settlement:%s", settlementTime.Format(time.RFC3339)),
+							MainnetBTCUSDTMetadataID,
+						}, extraMetadata...),
+						PriceMonitoringParameters: &vega.PriceMonitoringParameters{
+							Triggers: []*vega.PriceMonitoringTrigger{
+								{
+									Horizon:          3600,
+									Probability:      "0.9999",
+									AuctionExtension: 120,
+								},
+								{
+									Horizon:          14400,
+									Probability:      "0.9999",
+									AuctionExtension: 180,
+								},
+								{
+									Horizon:          43200,
+									Probability:      "0.9999",
+									AuctionExtension: 300,
+								},
+							},
+						},
+						LiquidityMonitoringParameters: &vega.LiquidityMonitoringParameters{
+							TargetStakeParameters: &vega.TargetStakeParameters{
+								TimeWindow:    3600,
+								ScalingFactor: 1,
+							},
+							TriggeringRatio:  "0.7",
+							AuctionExtension: 1,
+						},
+
+						RiskParameters: &vega.NewMarketConfiguration_LogNormal{
+							LogNormal: &vega.LogNormalRiskModel{
+								RiskAversionParameter: 0.000001,
+								Tau:                   0.000009506426342,
+								Params: &vega.LogNormalModelParams{
+									Mu:    0,
+									R:     0,
+									Sigma: 1.5,
+								},
+							},
+						},
+						PositionDecimalPlaces:   MainnetBTCUSDTPositionDecimalPlaces,
+						LpPriceRange:            &[]string{"0.05"}[0],
+						LiquiditySlaParameters:  nil,
+						LinearSlippageFactor:    "0.001",
+						QuadraticSlippageFactor: "0",
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/governance/market/mainnet_doge_usdt.go
+++ b/governance/market/mainnet_doge_usdt.go
@@ -10,12 +10,12 @@ import (
 	"github.com/vegaprotocol/devopstools/tools"
 )
 
-const MainnetDogeUSDTMetadataID = "auto:mainnet_btc_usdt"
+const MainnetDogeUSDTMetadataID = "auto:mainnet_doge_usdt"
 
 var (
 	MainnetDogeUSDTOracleDecimalPlaces   = uint64(6)
 	MainnetDogeUSDTMarketSettlementHours = 24 * 31
-	MainnetDogeUSDTPositionDecimalPlaces = int64(4)
+	MainnetDogeUSDTPositionDecimalPlaces = int64(-3)
 	MainnetDogeUSDTDecimalPlaces         = uint64(5)
 )
 
@@ -26,7 +26,7 @@ func NewMainnetDogeUSDT(
 	closingTime time.Time,
 	enactmentTime time.Time,
 	extraMetadata []string,
-) (*commandspb.ProposalSubmission, error) {
+) *commandspb.ProposalSubmission {
 	reference := tools.RandAlphaNumericString(40)
 
 	nowTime := time.Now()
@@ -115,7 +115,7 @@ func NewMainnetDogeUSDT(
 						},
 						DecimalPlaces: MainnetDogeUSDTDecimalPlaces,
 						Metadata: append([]string{
-							"base:BTC",
+							"base:DOGE",
 							"quote:USDT",
 							fmt.Sprintf("enactment:%s", enactmentTime.Format(time.RFC3339)),
 							fmt.Sprintf("settlement:%s", settlementTime.Format(time.RFC3339)),
@@ -142,22 +142,27 @@ func NewMainnetDogeUSDT(
 						RiskParameters: &vega.NewMarketConfiguration_LogNormal{
 							LogNormal: &vega.LogNormalRiskModel{
 								RiskAversionParameter: 0.000001,
-								Tau:                   0.000009506426342,
+								Tau:                   0.0001140771161,
 								Params: &vega.LogNormalModelParams{
 									Mu:    0,
-									R:     0,
+									R:     0.016,
 									Sigma: 1.5,
 								},
 							},
 						},
-						PositionDecimalPlaces:   MainnetDogeUSDTPositionDecimalPlaces,
-						LpPriceRange:            &[]string{"0.05"}[0],
-						LiquiditySlaParameters:  nil,
+						PositionDecimalPlaces: MainnetDogeUSDTPositionDecimalPlaces,
+						LpPriceRange:          &[]string{"0.8"}[0],
+						LiquiditySlaParameters: &vega.LiquiditySLAParameters{
+							PerformanceHysteresisEpochs: 1,
+							PriceRange:                  "0.05",
+							SlaCompetitionFactor:        "0.90",
+							CommitmentMinTimeFraction:   "0.95",
+						},
 						LinearSlippageFactor:    "0.001",
 						QuadraticSlippageFactor: "0",
 					},
 				},
 			},
 		},
-	}, nil
+	}
 }

--- a/governance/market/mainnet_doge_usdt.go
+++ b/governance/market/mainnet_doge_usdt.go
@@ -1,0 +1,163 @@
+package market
+
+import (
+	"fmt"
+	"time"
+
+	"code.vegaprotocol.io/vega/protos/vega"
+	commandspb "code.vegaprotocol.io/vega/protos/vega/commands/v1"
+	datav1 "code.vegaprotocol.io/vega/protos/vega/data/v1"
+	"github.com/vegaprotocol/devopstools/tools"
+)
+
+const MainnetDogeUSDTMetadataID = "auto:mainnet_btc_usdt"
+
+var (
+	MainnetDogeUSDTOracleDecimalPlaces   = uint64(6)
+	MainnetDogeUSDTMarketSettlementHours = 24 * 31
+	MainnetDogeUSDTPositionDecimalPlaces = int64(4)
+	MainnetDogeUSDTDecimalPlaces         = uint64(5)
+)
+
+// settlementVegaAssetId ideally with 6 decimal places
+func NewMainnetDogeUSDT(
+	settlementVegaAssetId string,
+	oraclePubKey string,
+	closingTime time.Time,
+	enactmentTime time.Time,
+	extraMetadata []string,
+) (*commandspb.ProposalSubmission, error) {
+	reference := tools.RandAlphaNumericString(40)
+
+	nowTime := time.Now()
+	settlementTime := nowTime.Add(time.Hour * (time.Duration(MainnetDogeUSDTMarketSettlementHours)))
+
+	return &commandspb.ProposalSubmission{
+		Reference: reference,
+		Rationale: &vega.ProposalRationale{
+			Title:       "DOGE/USDT Mainnet Copy",
+			Description: `As many of you know memecoins despite being memes receive a lot of attention in the ecosystem and therefore, volume. DOGE is no exception to this with quite a large market cap and avg. daily trading volume. I believe a DOGE/USDT market on Vega will be instrumental in driving new users to try and trade on the network.`,
+		},
+
+		Terms: &vega.ProposalTerms{
+			ClosingTimestamp:   closingTime.Unix(),
+			EnactmentTimestamp: enactmentTime.Unix(),
+			Change: &vega.ProposalTerms_NewMarket{
+				NewMarket: &vega.NewMarket{
+					Changes: &vega.NewMarketConfiguration{
+						Instrument: &vega.InstrumentConfiguration{
+							Name: "DOGE/USDT Mainnet Copy",
+							Code: "DOGE/USDT-MAINNET",
+							Product: &vega.InstrumentConfiguration_Future{
+								Future: &vega.FutureProduct{
+									SettlementAsset: settlementVegaAssetId,
+									QuoteName:       "USDT",
+									DataSourceSpecForSettlementData: &vega.DataSourceDefinition{
+										SourceType: &vega.DataSourceDefinition_External{
+											External: &vega.DataSourceDefinitionExternal{
+												SourceType: &vega.DataSourceDefinitionExternal_Oracle{
+													Oracle: &vega.DataSourceSpecConfiguration{
+														Signers: []*datav1.Signer{
+															{
+																Signer: &datav1.Signer_EthAddress{
+																	EthAddress: &datav1.ETHAddress{
+																		Address: oraclePubKey,
+																	},
+																},
+															},
+														},
+														Filters: []*datav1.Filter{
+															{
+																Key: &datav1.PropertyKey{
+																	Name:                "prices.DOGE.value",
+																	Type:                datav1.PropertyKey_TYPE_INTEGER,
+																	NumberDecimalPlaces: &MainnetDogeUSDTOracleDecimalPlaces,
+																},
+																Conditions: []*datav1.Condition{
+																	{
+																		Operator: datav1.Condition_OPERATOR_GREATER_THAN,
+																		Value:    "0",
+																	},
+																	{
+																		Operator: datav1.Condition_OPERATOR_LESS_THAN,
+																		Value:    "0",
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									DataSourceSpecForTradingTermination: &vega.DataSourceDefinition{
+										SourceType: &vega.DataSourceDefinition_Internal{
+											Internal: &vega.DataSourceDefinitionInternal{
+												SourceType: &vega.DataSourceDefinitionInternal_Time{
+													Time: &vega.DataSourceSpecConfigurationTime{
+														Conditions: []*datav1.Condition{
+															{
+																Operator: datav1.Condition_OPERATOR_GREATER_THAN_OR_EQUAL,
+																Value:    fmt.Sprintf("%d", settlementTime.Unix()),
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									DataSourceSpecBinding: &vega.DataSourceSpecToFutureBinding{
+										SettlementDataProperty:     "prices.DOGE.value",
+										TradingTerminationProperty: "vegaprotocol.builtin.timestamp",
+									},
+								},
+							},
+						},
+						DecimalPlaces: MainnetDogeUSDTDecimalPlaces,
+						Metadata: append([]string{
+							"base:BTC",
+							"quote:USDT",
+							fmt.Sprintf("enactment:%s", enactmentTime.Format(time.RFC3339)),
+							fmt.Sprintf("settlement:%s", settlementTime.Format(time.RFC3339)),
+							MainnetDogeUSDTMetadataID,
+						}, extraMetadata...),
+						PriceMonitoringParameters: &vega.PriceMonitoringParameters{
+							Triggers: []*vega.PriceMonitoringTrigger{
+								{
+									Horizon:          43200,
+									Probability:      "0.9999",
+									AuctionExtension: 600,
+								},
+							},
+						},
+						LiquidityMonitoringParameters: &vega.LiquidityMonitoringParameters{
+							TargetStakeParameters: &vega.TargetStakeParameters{
+								TimeWindow:    3600,
+								ScalingFactor: 1,
+							},
+							TriggeringRatio:  "0.7",
+							AuctionExtension: 1,
+						},
+
+						RiskParameters: &vega.NewMarketConfiguration_LogNormal{
+							LogNormal: &vega.LogNormalRiskModel{
+								RiskAversionParameter: 0.000001,
+								Tau:                   0.000009506426342,
+								Params: &vega.LogNormalModelParams{
+									Mu:    0,
+									R:     0,
+									Sigma: 1.5,
+								},
+							},
+						},
+						PositionDecimalPlaces:   MainnetDogeUSDTPositionDecimalPlaces,
+						LpPriceRange:            &[]string{"0.05"}[0],
+						LiquiditySlaParameters:  nil,
+						LinearSlippageFactor:    "0.001",
+						QuadraticSlippageFactor: "0",
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/governance/market/mainnet_eth_usdt.go
+++ b/governance/market/mainnet_eth_usdt.go
@@ -26,7 +26,7 @@ func NewMainnetETHUSDT(
 	closingTime time.Time,
 	enactmentTime time.Time,
 	extraMetadata []string,
-) (*commandspb.ProposalSubmission, error) {
+) *commandspb.ProposalSubmission {
 	reference := tools.RandAlphaNumericString(40)
 
 	nowTime := time.Now()
@@ -180,14 +180,19 @@ This proposal requests to list ETH/USDT-231231 as a market with USDT as a settle
 								},
 							},
 						},
-						PositionDecimalPlaces:   MainnetETHUSDTPositionDecimalPlaces,
-						LpPriceRange:            &[]string{"0.05"}[0],
-						LiquiditySlaParameters:  nil,
+						PositionDecimalPlaces: MainnetETHUSDTPositionDecimalPlaces,
+						LpPriceRange:          &[]string{"0.05"}[0],
+						LiquiditySlaParameters: &vega.LiquiditySLAParameters{
+							PerformanceHysteresisEpochs: 1,
+							PriceRange:                  "0.05",
+							SlaCompetitionFactor:        "0.90",
+							CommitmentMinTimeFraction:   "0.95",
+						},
 						LinearSlippageFactor:    "0.001",
 						QuadraticSlippageFactor: "0",
 					},
 				},
 			},
 		},
-	}, nil
+	}
 }

--- a/governance/market/mainnet_eth_usdt.go
+++ b/governance/market/mainnet_eth_usdt.go
@@ -10,42 +10,41 @@ import (
 	"github.com/vegaprotocol/devopstools/tools"
 )
 
-const MainnetLinkUSDTMetadataID = "auto:mainnet_link_usdt"
+const MainnetETHUSDTMetadataID = "auto:mainnet_eth_usdt"
 
 var (
-	MainnetLinkUSDTOracleDecimalPlaces   = uint64(6)
-	MainnetLinkUSDTMarketSettlementHours = 24 * 31
-	MainnetLinkUSDTPositionDecimalPlaces = int64(1)
-	MainnetLinkUSDTDecimalPlaces         = uint64(3)
+	MainnetETHUSDTOracleDecimalPlaces   = uint64(6)
+	MainnetETHUSDTMarketSettlementHours = 24 * 31
+	MainnetETHUSDTPositionDecimalPlaces = int64(3)
+	MainnetETHUSDTDecimalPlaces         = uint64(2)
 )
 
 // settlementVegaAssetId ideally with 6 decimal places
-func NewMainnetLinkUSDT(
+func NewMainnetETHUSDT(
 	settlementVegaAssetId string,
 	oraclePubKey string,
 	closingTime time.Time,
 	enactmentTime time.Time,
 	extraMetadata []string,
 ) (*commandspb.ProposalSubmission, error) {
-
 	reference := tools.RandAlphaNumericString(40)
 
 	nowTime := time.Now()
-	settlementTime := nowTime.Add(time.Hour * (time.Duration(MainnetLinkUSDTMarketSettlementHours)))
+	settlementTime := nowTime.Add(time.Hour * (time.Duration(MainnetETHUSDTMarketSettlementHours)))
 
 	return &commandspb.ProposalSubmission{
 		Reference: reference,
 		Rationale: &vega.ProposalRationale{
-			Title: "LINK/USDT Mainnet Copy",
+			Title: "ETH/USDT Mainnet Copy",
 			Description: `# Summary
 
-This proposal requests to list LINK/USDT-231231 as a market with USDT as a settlement asset on the Vega Network as discussed in: https://community.vega.xyz/.
-
+This proposal requests to list ETH/USDT-231231 as a market with USDT as a settlement asset on the Vega Network as discussed in: https://community.vega.xyz/.
+			
 # Rationale
 
-	* LINK is among the top 20 largest Crypto asset with the highest volume and Marketcap.
-	* Given the price, 3 decimal places will be used for price due to the number of valid digits in asset price.
-	* Position decimal places will be set to 2 considering the value per contract
+	* ETH is the largest Crypto asset with the highest volume and Marketcap.
+	* Given the price, 2 decimal places will be used for price due to the number of valid digits in asset price.
+	* Position decimal places will be set to 3 considering the value per contract
 	* USDT is chosen as settlement asset due to its stability.`,
 		},
 
@@ -56,8 +55,8 @@ This proposal requests to list LINK/USDT-231231 as a market with USDT as a settl
 				NewMarket: &vega.NewMarket{
 					Changes: &vega.NewMarketConfiguration{
 						Instrument: &vega.InstrumentConfiguration{
-							Name: "LINK/USDT Mainnet Copy",
-							Code: "LINK/USDT-MAINNET",
+							Name: "ETH/USDT Mainnet Copy",
+							Code: "ETH/USDT-MAINNET",
 							Product: &vega.InstrumentConfiguration_Future{
 								Future: &vega.FutureProduct{
 									SettlementAsset: settlementVegaAssetId,
@@ -79,9 +78,9 @@ This proposal requests to list LINK/USDT-231231 as a market with USDT as a settl
 														Filters: []*datav1.Filter{
 															{
 																Key: &datav1.PropertyKey{
-																	Name:                "prices.LINK.value",
+																	Name:                "prices.ETH.value",
 																	Type:                datav1.PropertyKey_TYPE_INTEGER,
-																	NumberDecimalPlaces: &MainnetLinkUSDTOracleDecimalPlaces,
+																	NumberDecimalPlaces: &MainnetETHUSDTOracleDecimalPlaces,
 																},
 																Conditions: []*datav1.Condition{
 																	{
@@ -92,7 +91,7 @@ This proposal requests to list LINK/USDT-231231 as a market with USDT as a settl
 															},
 															{
 																Key: &datav1.PropertyKey{
-																	Name: "prices.LINK.timestamp",
+																	Name: "prices.ETH.timestamp",
 																	Type: datav1.PropertyKey_TYPE_TIMESTAMP,
 																},
 																Conditions: []*datav1.Condition{
@@ -125,22 +124,22 @@ This proposal requests to list LINK/USDT-231231 as a market with USDT as a settl
 										},
 									},
 									DataSourceSpecBinding: &vega.DataSourceSpecToFutureBinding{
-										SettlementDataProperty:     "prices.LINK.value",
+										SettlementDataProperty:     "prices.ETH.value",
 										TradingTerminationProperty: "vegaprotocol.builtin.timestamp",
 									},
 								},
 							},
 						},
-						DecimalPlaces: MainnetLinkUSDTDecimalPlaces,
+						DecimalPlaces: MainnetETHUSDTDecimalPlaces,
 						Metadata: append([]string{
-							"base:LINK",
+							"base:ETH",
 							"quote:USDT",
 							"class:fx/crypto",
 							"quarterly",
 							"sector:defi",
 							fmt.Sprintf("enactment:%s", enactmentTime.Format(time.RFC3339)),
 							fmt.Sprintf("settlement:%s", settlementTime.Format(time.RFC3339)),
-							MainnetLinkUSDTMetadataID,
+							MainnetETHUSDTMetadataID,
 						}, extraMetadata...),
 						PriceMonitoringParameters: &vega.PriceMonitoringParameters{
 							Triggers: []*vega.PriceMonitoringTrigger{
@@ -181,7 +180,7 @@ This proposal requests to list LINK/USDT-231231 as a market with USDT as a settl
 								},
 							},
 						},
-						PositionDecimalPlaces:   MainnetLinkUSDTPositionDecimalPlaces,
+						PositionDecimalPlaces:   MainnetETHUSDTPositionDecimalPlaces,
 						LpPriceRange:            &[]string{"0.05"}[0],
 						LiquiditySlaParameters:  nil,
 						LinearSlippageFactor:    "0.001",

--- a/governance/market/mainnet_link_usdt.go
+++ b/governance/market/mainnet_link_usdt.go
@@ -1,0 +1,197 @@
+package market
+
+import (
+	"fmt"
+	"time"
+
+	"code.vegaprotocol.io/vega/protos/vega"
+	commandspb "code.vegaprotocol.io/vega/protos/vega/commands/v1"
+	datav1 "code.vegaprotocol.io/vega/protos/vega/data/v1"
+	"github.com/vegaprotocol/devopstools/tools"
+)
+
+const MainnetLinkUSDTMetadataID = "auto:mainnet_link_usdt"
+
+var (
+	MainnetLinkUSDTOracleDecimalPlaces   = uint64(6)
+	MainnetLinkUSDTMarketSettlementHours = 24 * 31
+	MainnetLinkUSDTPositionDecimalPlaces = int64(1)
+	MainnetLinkUSDTDecimalPlaces         = uint64(3)
+)
+
+// settlementVegaAssetId ideally with 6 decimal places
+func NewMainnetLinkUSDT(
+	settlementVegaAssetId string,
+	decimalPlaces uint64,
+	oraclePubKey string,
+	closingTime time.Time,
+	enactmentTime time.Time,
+	extraMetadata []string,
+) (*commandspb.ProposalSubmission, error) {
+	if decimalPlaces != 6 {
+		return nil, fmt.Errorf("asset decimal places for market %s(%s) must be 6", "ETH/USDT expiry 2023 June 30th", settlementVegaAssetId)
+	}
+
+	reference := tools.RandAlphaNumericString(40)
+
+	nowTime := time.Now()
+	settlementTime := nowTime.Add(time.Hour * (time.Duration(MainnetLinkUSDTMarketSettlementHours)))
+
+	return &commandspb.ProposalSubmission{
+		Reference: reference,
+		Rationale: &vega.ProposalRationale{
+			Title: "LINK/USDT",
+			Description: `# Summary
+
+This proposal requests to list LINK/USDT-231231 as a market with USDT as a settlement asset on the Vega Network as discussed in: https://community.vega.xyz/.
+
+# Rationale
+
+	* LINK is among the top 20 largest Crypto asset with the highest volume and Marketcap.
+	* Given the price, 3 decimal places will be used for price due to the number of valid digits in asset price.
+	* Position decimal places will be set to 2 considering the value per contract
+	* USDT is chosen as settlement asset due to its stability.`,
+		},
+
+		Terms: &vega.ProposalTerms{
+			ClosingTimestamp:   closingTime.Unix(),
+			EnactmentTimestamp: enactmentTime.Unix(),
+			Change: &vega.ProposalTerms_NewMarket{
+				NewMarket: &vega.NewMarket{
+					Changes: &vega.NewMarketConfiguration{
+						Instrument: &vega.InstrumentConfiguration{
+							Name: "LINK/USDT expiry 2023 June 30th",
+							Code: "LINK/USDT-230630",
+							Product: &vega.InstrumentConfiguration_Future{
+								Future: &vega.FutureProduct{
+									SettlementAsset: settlementVegaAssetId,
+									QuoteName:       "USDC",
+									DataSourceSpecForSettlementData: &vega.DataSourceDefinition{
+										SourceType: &vega.DataSourceDefinition_External{
+											External: &vega.DataSourceDefinitionExternal{
+												SourceType: &vega.DataSourceDefinitionExternal_Oracle{
+													Oracle: &vega.DataSourceSpecConfiguration{
+														Signers: []*datav1.Signer{
+															{
+																Signer: &datav1.Signer_EthAddress{
+																	EthAddress: &datav1.ETHAddress{
+																		Address: oraclePubKey,
+																	},
+																},
+															},
+														},
+														Filters: []*datav1.Filter{
+															{
+																Key: &datav1.PropertyKey{
+																	Name:                "prices.LINK.value",
+																	Type:                datav1.PropertyKey_TYPE_INTEGER,
+																	NumberDecimalPlaces: &MainnetLinkUSDTOracleDecimalPlaces,
+																},
+																Conditions: []*datav1.Condition{
+																	{
+																		Operator: datav1.Condition_OPERATOR_GREATER_THAN,
+																		Value:    "0",
+																	},
+																},
+															},
+															{
+																Key: &datav1.PropertyKey{
+																	Name: "prices.LINK.timestamp",
+																	Type: datav1.PropertyKey_TYPE_TIMESTAMP,
+																},
+																Conditions: []*datav1.Condition{
+																	{
+																		Operator: datav1.Condition_OPERATOR_GREATER_THAN_OR_EQUAL,
+																		Value:    fmt.Sprintf("%d", settlementTime.Unix()),
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									DataSourceSpecForTradingTermination: &vega.DataSourceDefinition{
+										SourceType: &vega.DataSourceDefinition_Internal{
+											Internal: &vega.DataSourceDefinitionInternal{
+												SourceType: &vega.DataSourceDefinitionInternal_Time{
+													Time: &vega.DataSourceSpecConfigurationTime{
+														Conditions: []*datav1.Condition{
+															{
+																Operator: datav1.Condition_OPERATOR_GREATER_THAN_OR_EQUAL,
+																Value:    fmt.Sprintf("%d", settlementTime.Unix()),
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									DataSourceSpecBinding: &vega.DataSourceSpecToFutureBinding{
+										SettlementDataProperty:     "prices.LINK.value",
+										TradingTerminationProperty: "vegaprotocol.builtin.timestamp",
+									},
+								},
+							},
+						},
+						DecimalPlaces: MainnetLinkUSDTDecimalPlaces,
+						Metadata: append([]string{
+							"base:LINK",
+							"quote:USDT",
+							"class:fx/crypto",
+							"quarterly",
+							"sector:defi",
+							"enactment:2023-10-04T08:00:00Z",
+							fmt.Sprintf("settlement:%s   2023-12-31T08:00:00Z", settlementTime.Format(time.RFC3339)),
+						}, extraMetadata...),
+						PriceMonitoringParameters: &vega.PriceMonitoringParameters{
+							Triggers: []*vega.PriceMonitoringTrigger{
+								{
+									Horizon:          3600,
+									Probability:      "0.9999",
+									AuctionExtension: 120,
+								},
+								{
+									Horizon:          14400,
+									Probability:      "0.9999",
+									AuctionExtension: 180,
+								},
+								{
+									Horizon:          43200,
+									Probability:      "0.9999",
+									AuctionExtension: 300,
+								},
+							},
+						},
+						LiquidityMonitoringParameters: &vega.LiquidityMonitoringParameters{
+							TargetStakeParameters: &vega.TargetStakeParameters{
+								TimeWindow:    3600,
+								ScalingFactor: 1,
+							},
+							TriggeringRatio:  "0.7",
+							AuctionExtension: 1,
+						},
+
+						RiskParameters: &vega.NewMarketConfiguration_LogNormal{
+							LogNormal: &vega.LogNormalRiskModel{
+								RiskAversionParameter: 0.000001,
+								Tau:                   0.000009506426342,
+								Params: &vega.LogNormalModelParams{
+									Mu:    0,
+									R:     0,
+									Sigma: 1.5,
+								},
+							},
+						},
+						PositionDecimalPlaces:   MainnetLinkUSDTPositionDecimalPlaces,
+						LpPriceRange:            &[]string{"0.05"}[0],
+						LiquiditySlaParameters:  nil,
+						LinearSlippageFactor:    "0.001",
+						QuadraticSlippageFactor: "0",
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/governance/market/mainnet_link_usdt.go
+++ b/governance/market/mainnet_link_usdt.go
@@ -26,7 +26,7 @@ func NewMainnetLinkUSDT(
 	closingTime time.Time,
 	enactmentTime time.Time,
 	extraMetadata []string,
-) (*commandspb.ProposalSubmission, error) {
+) *commandspb.ProposalSubmission {
 
 	reference := tools.RandAlphaNumericString(40)
 
@@ -181,14 +181,19 @@ This proposal requests to list LINK/USDT-231231 as a market with USDT as a settl
 								},
 							},
 						},
-						PositionDecimalPlaces:   MainnetLinkUSDTPositionDecimalPlaces,
-						LpPriceRange:            &[]string{"0.05"}[0],
-						LiquiditySlaParameters:  nil,
+						PositionDecimalPlaces: MainnetLinkUSDTPositionDecimalPlaces,
+						LpPriceRange:          &[]string{"0.05"}[0],
+						LiquiditySlaParameters: &vega.LiquiditySLAParameters{
+							PerformanceHysteresisEpochs: 1,
+							PriceRange:                  "0.05",
+							SlaCompetitionFactor:        "0.90",
+							CommitmentMinTimeFraction:   "0.95",
+						},
 						LinearSlippageFactor:    "0.001",
 						QuadraticSlippageFactor: "0",
 					},
 				},
 			},
 		},
-	}, nil
+	}
 }

--- a/governance/market/mainnet_link_usdt.go
+++ b/governance/market/mainnet_link_usdt.go
@@ -22,15 +22,11 @@ var (
 // settlementVegaAssetId ideally with 6 decimal places
 func NewMainnetLinkUSDT(
 	settlementVegaAssetId string,
-	decimalPlaces uint64,
 	oraclePubKey string,
 	closingTime time.Time,
 	enactmentTime time.Time,
 	extraMetadata []string,
 ) (*commandspb.ProposalSubmission, error) {
-	if decimalPlaces != 6 {
-		return nil, fmt.Errorf("asset decimal places for market %s(%s) must be 6", "ETH/USDT expiry 2023 June 30th", settlementVegaAssetId)
-	}
 
 	reference := tools.RandAlphaNumericString(40)
 
@@ -60,8 +56,8 @@ This proposal requests to list LINK/USDT-231231 as a market with USDT as a settl
 				NewMarket: &vega.NewMarket{
 					Changes: &vega.NewMarketConfiguration{
 						Instrument: &vega.InstrumentConfiguration{
-							Name: "LINK/USDT expiry 2023 June 30th",
-							Code: "LINK/USDT-230630",
+							Name: "LINK/USDT",
+							Code: "LINK/USDT-MAINNET",
 							Product: &vega.InstrumentConfiguration_Future{
 								Future: &vega.FutureProduct{
 									SettlementAsset: settlementVegaAssetId,
@@ -142,7 +138,8 @@ This proposal requests to list LINK/USDT-231231 as a market with USDT as a settl
 							"class:fx/crypto",
 							"quarterly",
 							"sector:defi",
-							"enactment:2023-10-04T08:00:00Z",
+							fmt.Sprintf("enactment:%s", enactmentTime.Format(time.RFC3339)),
+							MainnetLinkUSDTMetadataID,
 							fmt.Sprintf("settlement:%s   2023-12-31T08:00:00Z", settlementTime.Format(time.RFC3339)),
 						}, extraMetadata...),
 						PriceMonitoringParameters: &vega.PriceMonitoringParameters{


### PR DESCRIPTION
# Changes

- Filter markets for terminate command. We were trying to terminate the market even if they were already closed. Now we filter them out
- Added command to propose assets on the network
- Added Assets prepared by @daunatv 
- Added copy of the markets from the mainnet
   - Doge market: https://governance.vega.xyz/proposals/d957e1d0ce9dcc08bdbb5bfe637f1a601050d67f81fa6cdaeef64801166f6a28
   - Link market: https://governance.vega.xyz/proposals/ab9ffcfe46e3f01e9d8f105832b6e13855b81c06be1cd0f208d1d08a13e1b84d
   - BTC market: https://governance.vega.xyz/proposals/e001366a8e2e5079362205acf54edf096b2e949adfc2f8088b5061ebd11b8e9c
   - ETH market: https://governance.vega.xyz/proposals/39410c92ed75c175e6cc572372b8a2adfeb0261a06a4480142b224d87017948c