### PR TITLE
feat: fix the devnet referral program proposal

### DIFF
--- a/cmd/propose/referral.go
+++ b/cmd/propose/referral.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/vegaprotocol/devopstools/governance"
 	"github.com/vegaprotocol/devopstools/governance/programs"
+	"github.com/vegaprotocol/devopstools/types"
 	"github.com/vegaprotocol/devopstools/veganetwork"
 	"go.uber.org/zap"
 )
@@ -119,6 +120,10 @@ func setupNetworkParametersToSetupReferralProgram(
 		"referralProgram.maxReferralDiscountFactor":    "0.02",
 		"referralProgram.maxReferralRewardFactor":      "0.02",
 	}
+	if network.Network == types.NetworkDevnet1 {
+		updateParams["governance.proposal.referralProgram.requiredParticipation"] = "0.0001"
+	}
+
 	updateCount, err := governance.ProposeAndVoteOnNetworkParameters(
 		updateParams, network.VegaTokenWhale, network.NetworkParams, network.DataNodeClient, logger,
 	)


### PR DESCRIPTION
# Changed

- Vote `governance.proposal.referralProgram.requiredParticipation` to `0.01%` for devnet only. We want to vote it only for devnet, because parameters for other networks are driven by @daunatv  and @JonRay15 