### PR TITLE
feat: update epoch length to 30 min on stagnet1

### DIFF
--- a/cmd/incentive/network_params.go
+++ b/cmd/incentive/network_params.go
@@ -3,6 +3,7 @@ package incentive
 import (
 	"fmt"
 	"os"
+	"slices"
 
 	"github.com/spf13/cobra"
 	"github.com/vegaprotocol/devopstools/governance"
@@ -83,7 +84,7 @@ func expectedNetworkParams(env string) []expectedNetworkParameter {
 		{Name: "governance.proposal.transfer.minEnact", ExpectedValue: "1m"},
 	}
 
-	if env == types.NetworkFairground {
+	if slices.Contains(env, []string{types.NetworkStagnet1, types.NetworkFairground}) {
 		result = append(result, expectedNetworkParameter{
 			Name:          "validators.epoch.length",
 			ExpectedValue: "30m",


### PR DESCRIPTION
# Changes

- Updated validators.epoch.length to 30 min on stagnet1

close https://github.com/vegaprotocol/devopstools/issues/99 