### PR TITLE
feat: call vega tool to force pup flag to true for snapshot compatibi…

### DIFF
--- a/cmd/snapshotcompatibility/load-snapshot.go
+++ b/cmd/snapshotcompatibility/load-snapshot.go
@@ -176,6 +176,18 @@ func runLoadSnapshot(
 		}
 
 		logger.Info("Snapshot database loaded")
+
+		// force protocol-upgrade flag to be true in the snapshots
+		logger.Info("Forcing protocol-upgrade flag to true in snapshot")
+		snapshotToJSONArgs := []string{
+			"tools",
+			"snapshot",
+			"--set-pup",
+			"--home", validatorHomePath,
+		}
+		if _, err := tools.ExecuteBinary(vegaBinary, snapshotToJSONArgs, nil); err != nil {
+			return fmt.Errorf("failed to set protocol-upgrade flag in latest snapshot: %w", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
The snapshot-compatibility pipeline needs to use a new vega tool that will set the `protocolUpgrade` flag in the snapshot to `true` so that it looks like a snapshot that was taken due to a protocol upgrade.

More details here in the core PR (which needs to be merged in first!):
https://github.com/vegaprotocol/vega/pull/10196

This is the pipeline working when run against all the other branches with fixes in them:
https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fsystem-tests-snapshot-compatibility/detail/system-tests-snapshot-compatibility/168/pipeline

